### PR TITLE
Add account edit functionality

### DIFF
--- a/lang/de/text.php
+++ b/lang/de/text.php
@@ -106,6 +106,8 @@ return [
         "<p>Registrierte Benutzer können den Zugang zu privaten Bereichen anfordern.</p>",
 
     "saved" => "Gespeichert",
+    "account_updated" => "Konto aktualisiert",
+    "edit" => "Bearbeiten",
     "delete" => "Löschen",
     "users" => "Benutzer",
     "private" => "Privat",

--- a/lang/en/text.php
+++ b/lang/en/text.php
@@ -104,6 +104,8 @@ return [
         "<p>Registered Users can request access to private areas.</p>",
 
     "saved" => "Saved",
+    "account_updated" => "Account updated",
+    "edit" => "Edit",
     "delete" => "Delete",
     "users" => "Users",
     "user_deleted" => "User deleted",

--- a/resources/views/livewire/account.blade.php
+++ b/resources/views/livewire/account.blade.php
@@ -2,14 +2,26 @@
     <p>{{ __('text.logged_in_as', ['name' => $user->name]) }} @if ($user->isAdmin()) (Admin) @endif</p>
 
     <div class="p-2 border mb-3 rounded border-primary-dark dark:border-primary-light">
-        <div class="grid grid-cols-2">
-            <p><strong>{{ __('text.email') }}</strong></p>
-            <p>{{ $user->email }}</p>
-        </div>
-        <div class="grid grid-cols-2">
-            <p><strong>{{ __('text.username') }}</strong></p>
-            <p>{{ $user->username }}</p>
-        </div>
+        @if ($edit)
+            @include('global.partials.floating-label-input', ['id' => 'name', 'name' => 'name', 'label' => __('text.name'), 'livewire' => true])
+            @include('global.partials.floating-label-input', ['id' => 'email', 'name' => 'email', 'label' => __('text.email'), 'livewire' => true])
+            @include('global.partials.floating-label-input', ['id' => 'password', 'name' => 'password', 'label' => __('text.password'), 'type' => 'password', 'livewire' => true])
+            @include('global.partials.floating-label-input', ['id' => 'passwordConfirm', 'name' => 'passwordConfirm', 'label' => __('text.confirm_password'), 'type' => 'password', 'livewire' => true])
+            <div class="mt-3 flex gap-2">
+                <button class="btn" wire:click="saveAccount">{{ __('text.save') }}</button>
+                <button class="btn btn-secondary" wire:click="cancelEdit">{{ __('text.back') }}</button>
+            </div>
+        @else
+            <div class="grid grid-cols-2">
+                <p><strong>{{ __('text.email') }}</strong></p>
+                <p>{{ $user->email }}</p>
+            </div>
+            <div class="grid grid-cols-2">
+                <p><strong>{{ __('text.username') }}</strong></p>
+                <p>{{ $user->username }}</p>
+            </div>
+            <button class="btn mt-2" wire:click="editAccount">{{ __('text.edit') }}</button>
+        @endif
     </div>
 
     <h2>{{ __('text.permissions') }}</h2>
@@ -59,6 +71,11 @@
         @if (session()->has('status'))
             <div wire:transition.fade>
                 <div class="alert alert-success">{{ session('status') }}</div>
+            </div>
+        @endif
+        @if (session()->has('error'))
+            <div wire:transition.fade>
+                <div class="alert alert-danger">{{ session('error') }}</div>
             </div>
         @endif
     </div>


### PR DESCRIPTION
## Summary
- allow users to edit their account details (name, email, password)
- add edit form and error messages to account page
- update translations with new strings

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*