### PR TITLE
Add account edit layout improvements

### DIFF
--- a/lang/de/text.php
+++ b/lang/de/text.php
@@ -106,6 +106,8 @@ return [
         "<p>Registrierte Benutzer können den Zugang zu privaten Bereichen anfordern.</p>",
 
     "saved" => "Gespeichert",
+    "account_updated" => "Konto aktualisiert",
+    "edit" => "Bearbeiten",
     "delete" => "Löschen",
     "users" => "Benutzer",
     "private" => "Privat",

--- a/lang/en/text.php
+++ b/lang/en/text.php
@@ -104,6 +104,8 @@ return [
         "<p>Registered Users can request access to private areas.</p>",
 
     "saved" => "Saved",
+    "account_updated" => "Account updated",
+    "edit" => "Edit",
     "delete" => "Delete",
     "users" => "Users",
     "user_deleted" => "User deleted",

--- a/resources/views/global/partials/floating-label-input.blade.php
+++ b/resources/views/global/partials/floating-label-input.blade.php
@@ -9,5 +9,5 @@
     {{ isset($value) ? 'value=' . $value : '' }}
     {!! isset($additional) ? $additional : '' !!}
     />
-    <label for="{{ $id }}" class="ml-1.5 text-black absolute p-0 text-sm duration-300 transform -translate-y-4 scale-75 left-1 top-2 z-10 origin-[0] px-1 bg-white peer-focus:px-2 peer-focus:text-blue-600 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4 dark:bg-secondary-light dark:text-gray-400 rounded dark:peer-focus:text-white">{{ $label }}{{ isset($required) ? ' *' : ''}}</label>
+    <label for="{{ $id }}" class="ml-1.5 text-black absolute p-0 text-sm duration-300 transform -translate-y-4 scale-75 left-1 top-2 z-10 origin-[0] px-1 bg-white peer-focus:px-2 peer-focus:text-blue-600 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4 dark:bg-secondary-light dark:text-gray-300 rounded dark:peer-focus:text-white">{{ $label }}{{ isset($required) ? ' *' : ''}}</label>
 </div>

--- a/resources/views/livewire/account.blade.php
+++ b/resources/views/livewire/account.blade.php
@@ -2,14 +2,57 @@
     <p>{{ __('text.logged_in_as', ['name' => $user->name]) }} @if ($user->isAdmin()) (Admin) @endif</p>
 
     <div class="p-2 border mb-3 rounded border-primary-dark dark:border-primary-light">
-        <div class="grid grid-cols-2">
-            <p><strong>{{ __('text.email') }}</strong></p>
-            <p>{{ $user->email }}</p>
-        </div>
-        <div class="grid grid-cols-2">
-            <p><strong>{{ __('text.username') }}</strong></p>
-            <p>{{ $user->username }}</p>
-        </div>
+        @if ($edit)
+            <div class="grid grid-cols-2 md:grid-cols-1 gap-4">
+                @include('global.partials.floating-label-input', [
+                    'id' => 'name',
+                    'name' => 'name',
+                    'label' => __('text.name'),
+                    'livewire' => true,
+                    'wrapperClass' => 'w-full mb-3',
+                ])
+                @include('global.partials.floating-label-input', [
+                    'id' => 'email',
+                    'name' => 'email',
+                    'label' => __('text.email'),
+                    'livewire' => true,
+                    'wrapperClass' => 'w-full mb-3',
+                ])
+                @include('global.partials.floating-label-input', [
+                    'id' => 'password',
+                    'name' => 'password',
+                    'label' => __('text.password'),
+                    'type' => 'password',
+                    'livewire' => true,
+                    'wrapperClass' => 'w-full mb-3',
+                ])
+                @include('global.partials.floating-label-input', [
+                    'id' => 'passwordConfirm',
+                    'name' => 'passwordConfirm',
+                    'label' => __('text.confirm_password'),
+                    'type' => 'password',
+                    'livewire' => true,
+                    'wrapperClass' => 'w-full mb-3',
+                ])
+            </div>
+            <div class="mt-3 flex gap-4 items-center">
+                <button class="btn" wire:click="saveAccount">{{ __('text.save') }}</button>
+                <a wire:click="cancelEdit" class="flex items-center gap-2 py-auto hover:cursor-grab btn-back dark:invert dark:text-secondary-dark">
+                    <img class="w-4" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}" alt="Back Icon" />
+                    <span class="leading-none">{{ __('text.back') }}</span>
+                </a>
+            </div>
+        @else
+            <div class="grid grid-cols-2">
+                <p><strong>{{ __('text.email') }}</strong></p>
+                <p>{{ $user->email }}</p>
+            </div>
+            <div class="grid grid-cols-2">
+                <p><strong>{{ __('text.username') }}</strong></p>
+                <p>{{ $user->username }}</p>
+            </div>
+            <button class="btn mt-2" wire:click="editAccount">{{ __('text.edit') }}</button>
+        @endif
     </div>
 
     <h2>{{ __('text.permissions') }}</h2>
@@ -59,6 +102,11 @@
         @if (session()->has('status'))
             <div wire:transition.fade>
                 <div class="alert alert-success">{{ session('status') }}</div>
+            </div>
+        @endif
+        @if (session()->has('error'))
+            <div wire:transition.fade>
+                <div class="alert alert-danger">{{ session('error') }}</div>
             </div>
         @endif
     </div>

--- a/resources/views/livewire/account.blade.php
+++ b/resources/views/livewire/account.blade.php
@@ -3,7 +3,7 @@
 
     <div class="p-2 border mb-3 rounded border-primary-dark dark:border-primary-light">
         @if ($edit)
-            <div class="grid grid-cols-2 md:grid-cols-1 gap-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 @include('global.partials.floating-label-input', [
                     'id' => 'name',
                     'name' => 'name',


### PR DESCRIPTION
## Summary
- use responsive grid for editable account fields
- add spacing and consistent back button style on account page

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*