### PR TITLE
Add admin guard on account actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ In order to ensure that the Laravel community is welcoming to all, please review
 
 If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
 
+## Application Notes
+
+Only admin users can use the "login as user" and "delete user" actions in the
+account management Livewire component. Non-admins attempting to trigger these
+actions will now receive an HTTP 403 response. Unit tests covering this behavior
+are located in `tests/Unit/AccountAdminGuardTest.php`.
+
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/app/Livewire/Account.php
+++ b/app/Livewire/Account.php
@@ -64,6 +64,9 @@ class Account extends Component
 
     public function deleteUser($id)
     {
+        if (!Auth::user()->isAdmin()) {
+            abort(403);
+        }
         $user = User::find($id);
         if ($user) {
             $user->delete();
@@ -74,6 +77,9 @@ class Account extends Component
 
     public function loginUser($id)
     {
+        if (!Auth::user()->isAdmin()) {
+            abort(403);
+        }
         $user = User::find($id);
         if ($user) {
             Auth::login($user);

--- a/tests/Unit/AccountAdminGuardTest.php
+++ b/tests/Unit/AccountAdminGuardTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Livewire\Account;
+use App\Models\User;
+use Livewire\Livewire;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AccountAdminGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_non_admin_cannot_delete_user(): void
+    {
+        $nonAdmin = User::factory()->create(['username' => 'regular']);
+        $target = User::factory()->create();
+
+        $this->actingAs($nonAdmin);
+
+        Livewire::test(Account::class)
+            ->call('deleteUser', $target->id)
+            ->assertForbidden();
+    }
+
+    public function test_non_admin_cannot_login_user(): void
+    {
+        $nonAdmin = User::factory()->create(['username' => 'regular']);
+        $target = User::factory()->create();
+
+        $this->actingAs($nonAdmin);
+
+        Livewire::test(Account::class)
+            ->call('loginUser', $target->id)
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- restrict `loginUser()` and `deleteUser()` actions in `Account` Livewire component to admins
- document account admin restrictions
- test admin guard on account actions

## Testing
- `./vendor/bin/phpunit` *(fails: could not find driver, manifest not found)*