### PR TITLE
Fix mobile overflow for CV

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -183,6 +183,7 @@ tertiary-light    #FFFFFF
     @font-face{font-family:"Fira Code";font-style:normal;font-weight:700;src:url("../font/static/FiraCode-Bold.ttf") format("truetype");}
 
     html {@apply h-full overflow-x-hidden; font-family:"Fira Code";}
+    body {@apply overflow-x-hidden;}
     .chevron.rotate {@apply rotate-180;}
 
     /* ───────── language dropdown, nav toggle (unchanged) ───────── */


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling caused by CV animations by hiding overflow on the body element

## Testing
- `./vendor/bin/phpunit` *(fails: could not find driver)*