### PR TITLE
Add queued crawler with progress polling

### DIFF
--- a/app/Jobs/CrawlTestRunJob.php
+++ b/app/Jobs/CrawlTestRunJob.php
@@ -1,0 +1,52 @@
+<?php
+namespace App\Jobs;
+
+use App\Models\Testobject;
+use App\Models\Testrun;
+use App\Models\Testinstance;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+
+class CrawlTestRunJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected int $testobjectId;
+    protected string $url;
+
+    public function __construct(int $testobjectId, string $url)
+    {
+        $this->testobjectId = $testobjectId;
+        $this->url = $url;
+    }
+
+    public function handle(): void
+    {
+        $testobject = Testobject::find($this->testobjectId);
+        if (!$testobject) {
+            return;
+        }
+
+        $testrun = new Testrun();
+        $testrun->testobject_id = $testobject->id;
+        $testrun->url = $this->url;
+        $testrun->name = $this->url;
+        $testrun->save();
+
+        $instance = new Testinstance();
+        $instance->testrun_id = $testrun->id;
+        $instance->save();
+        $instance->fetch();
+
+        $path = 'crawler_status.json';
+        if (Storage::exists($path)) {
+            $status = json_decode(Storage::get($path), true);
+            $status['completed'] = ($status['completed'] ?? 0) + 1;
+            Storage::put($path, json_encode($status));
+        }
+    }
+}

--- a/lang/de/text.php
+++ b/lang/de/text.php
@@ -52,6 +52,8 @@ return [
     "fetch_all" => "Alle abrufen",
     "bulk_diff" => "Alle vergleichen",
     "crawl_completed" => "Crawl abgeschlossen. Gefundene Links:",
+    "crawl_started" => "Crawl in Warteschlange",
+    "processed" => "verarbeitet",
     "fetch_completed" => "Abrufen abgeschlossen",
     "random-teams" => "Zufallsteams",
     "players" => "Spieler",

--- a/lang/en/text.php
+++ b/lang/en/text.php
@@ -52,6 +52,8 @@ return [
     "fetch_all" => "Fetch All",
     "bulk_diff" => "Bulk Diff",
     "crawl_completed" => "Crawl completed. Links found:",
+    "crawl_started" => "Crawl queued",
+    "processed" => "processed",
     "fetch_completed" => "Fetching completed",
     "random-teams" => "Random Teams",
     "players" => "Players",

--- a/resources/views/livewire/testobject.blade.php
+++ b/resources/views/livewire/testobject.blade.php
@@ -29,6 +29,12 @@
         {{ __('text.bulk_diff') }}
     </button>
 
+    <div wire:poll.1000ms="updateStatus">
+        @if ($crawlStatus)
+            <p>{{ $crawlStatus['completed'] }} / {{ $crawlStatus['total'] }} {{ __('text.processed') }}</p>
+        @endif
+    </div>
+
     {!! $bulkDiffContent ?? '' !!}
 
     @foreach ($testobject->testruns as $testrun)


### PR DESCRIPTION
## Summary
- queue test run creation via new `CrawlTestRunJob`
- track crawler progress in `storage/app/crawler_status.json`
- poll crawler status in the Testobject component every second
- show processed count in the tester UI
- add translations for new status texts

## Testing
- `php artisan test` *(fails: could not find driver)*