### PR TITLE
Enable recursive crawl job processing

### DIFF
--- a/app/Jobs/CrawlTestRunJob.php
+++ b/app/Jobs/CrawlTestRunJob.php
@@ -4,6 +4,9 @@ namespace App\Jobs;
 use App\Models\Testobject;
 use App\Models\Testrun;
 use App\Models\Testinstance;
+use App\Utilities\CrawlerUtility;
+use GuzzleHttp\Client;
+use DOMDocument;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -29,6 +32,54 @@ class CrawlTestRunJob implements ShouldQueue
         $testobject = Testobject::find($this->testobjectId);
         if (!$testobject) {
             return;
+        }
+
+        if (
+            Testrun::where('testobject_id', $testobject->id)
+                ->where('url', $this->url)
+                ->exists()
+        ) {
+            return;
+        }
+
+        $client = new Client(['http_errors' => false]);
+        $html = '';
+        try {
+            $response = $client->get($this->url);
+            $html = (string) $response->getBody();
+        } catch (\Exception $e) {
+        }
+
+        $dom = new DOMDocument();
+        @$dom->loadHTML($html);
+        $baseDomain = parse_url($testobject->url, PHP_URL_HOST);
+
+        foreach ($dom->getElementsByTagName('a') as $a) {
+            $href = $a->getAttribute('href');
+            if (!$href) {
+                continue;
+            }
+            $abs = CrawlerUtility::makeAbsolute($href, $this->url);
+            if (!$abs) {
+                continue;
+            }
+            $parsed = parse_url($abs);
+            if (($parsed['host'] ?? '') === $baseDomain) {
+                if (
+                    !Testrun::where('testobject_id', $testobject->id)
+                        ->where('url', $abs)
+                        ->exists()
+                ) {
+                    $path = 'crawler_status.json';
+                    if (Storage::exists($path)) {
+                        $status = json_decode(Storage::get($path), true);
+                        $status['total'] = ($status['total'] ?? 0) + 1;
+                        Storage::put($path, json_encode($status));
+                    }
+
+                    self::dispatch($testobject->id, $abs);
+                }
+            }
         }
 
         $testrun = new Testrun();

--- a/app/Livewire/Testobject.php
+++ b/app/Livewire/Testobject.php
@@ -71,16 +71,12 @@ class Testobject extends Component
 
     public function crawlDomain()
     {
-        $links = CrawlerUtility::crawl($this->testobject);
-
         Storage::put('crawler_status.json', json_encode([
-            'total' => count($links),
+            'total' => 1,
             'completed' => 0,
         ]));
 
-        foreach ($links as $link) {
-            CrawlTestRunJob::dispatch($this->testobject->id, $link);
-        }
+        CrawlTestRunJob::dispatch($this->testobject->id, $this->testobject->url);
 
         $this->testobject->refresh();
         session()->flash('message', __('text.crawl_started'));

--- a/app/Utilities/CrawlerUtility.php
+++ b/app/Utilities/CrawlerUtility.php
@@ -56,7 +56,7 @@ class CrawlerUtility
         return $links;
     }
 
-    protected static function makeAbsolute(string $href, string $base): ?string
+    public static function makeAbsolute(string $href, string $base): ?string
     {
         try {
             $baseUri = new Uri($base);


### PR DESCRIPTION
## Summary
- make `CrawlerUtility::makeAbsolute` public
- modify `CrawlTestRunJob` to recursively queue URLs, parse links and update crawl progress
- start crawl queue with a single root job

## Testing
- `./vendor/bin/phpunit` *(fails: could not find driver)*