### PR TITLE
Add sitemaps support to tester

### DIFF
--- a/app/Http/Controllers/TesterController.php
+++ b/app/Http/Controllers/TesterController.php
@@ -88,4 +88,10 @@ class TesterController extends Controller
 
         return view("tester.diff", ["error" => "Some Erro"]);
     }
+
+    public function testerObjectDiff($id)
+    {
+        $testobject = Testobject::find($id);
+        return view("tester.objectdiff", ["testobject" => $testobject]);
+    }
 }

--- a/app/Livewire/TestobjectDiff.php
+++ b/app/Livewire/TestobjectDiff.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class TestobjectDiff extends Component
+{
+    public $testobject;
+    public $diff;
+    public $instanceCount = 0;
+
+    public $instanceOne = 1;
+    public $instanceTwo = 0;
+
+    public function mount() {
+        $html = "";
+        foreach ($this->testobject->testruns as $run) {
+            if ($run->testinstances->count() > $this->instanceCount) {
+                $this->instanceCount = $run->testinstances->count();
+            }
+
+            if (
+                $run->testinstances->count() >= 2 &&
+                    isset($run->testinstances[$this->instanceOne]) &&
+                    isset($run->testinstances[$this->instanceTwo])
+            ) {
+                $a = $run->testinstances[$this->instanceOne];
+                $b = $run->testinstances[$this->instanceTwo];
+                $html .= "<h3>" . e($run->name) . "</h3>";
+                $html .= $a->diff($b, "Inline");
+            }
+        }
+        $this->diff = $html;
+    }
+
+    public function render()
+    {
+        return view('livewire.testobject-diff');
+    }
+}

--- a/app/Models/Testobject.php
+++ b/app/Models/Testobject.php
@@ -18,9 +18,14 @@ class Testobject extends Model
         "url" => "",
         "delete_after" => 86400,
         "user" => 0,
+        "sitemaps" => "[]",
     ];
 
-    protected $fillable = ["name", "url", "delete_after", "user"];
+    protected $fillable = ["name", "url", "delete_after", "user", "sitemaps"];
+
+    protected $casts = [
+        'sitemaps' => 'array',
+    ];
 
     public function getCreatedAtCleanAttribute($value)
     {

--- a/database/migrations/2025_05_26_090500_add_sitemaps_to_testobject.php
+++ b/database/migrations/2025_05_26_090500_add_sitemaps_to_testobject.php
@@ -1,0 +1,21 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('testobject', function (Blueprint $table) {
+            $table->json('sitemaps')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('testobject', function (Blueprint $table) {
+            $table->dropColumn('sitemaps');
+        });
+    }
+};

--- a/lang/de/text.php
+++ b/lang/de/text.php
@@ -51,6 +51,8 @@ return [
     "crawl" => "Crawlen",
     "fetch_all" => "Alle abrufen",
     "bulk_diff" => "Alle vergleichen",
+    "sitemaps" => "Sitemaps",
+    "run_sitemaps" => "Sitemaps ausführen",
     "crawl_completed" => "Crawl abgeschlossen. Gefundene Links:",
     "crawl_started" => "Crawl in Warteschlange",
     "processed" => "verarbeitet",

--- a/lang/en/text.php
+++ b/lang/en/text.php
@@ -51,6 +51,8 @@ return [
     "crawl" => "Crawl",
     "fetch_all" => "Fetch All",
     "bulk_diff" => "Bulk Diff",
+    "sitemaps" => "Sitemaps",
+    "run_sitemaps" => "Run Sitemaps",
     "crawl_completed" => "Crawl completed. Links found:",
     "crawl_started" => "Crawl queued",
     "processed" => "processed",

--- a/resources/views/livewire/testobject-diff.blade.php
+++ b/resources/views/livewire/testobject-diff.blade.php
@@ -1,0 +1,4 @@
+<div>
+    {{-- A good traveler has no fixed plans and is not intent upon arriving. --}}
+    {!! $diff !!}
+</div>

--- a/resources/views/livewire/testobject.blade.php
+++ b/resources/views/livewire/testobject.blade.php
@@ -22,6 +22,11 @@
     <button class="btn mb-3" wire:click="crawlDomain">
         {{ __('text.crawl') }}
     </button>
+    <div class="mb-3">
+        <p class="mb-1">{{ __('text.sitemaps') }}</p>
+        <textarea rows="3" class="w-full mb-2 rounded dark:bg-secondary-light" wire:model="sitemapsInput"></textarea>
+        <button class="btn" wire:click="runSitemaps">{{ __('text.run_sitemaps') }}</button>
+    </div>
     <button class="btn mb-3" wire:click="fetchAll">
         {{ __('text.fetch_all') }}
     </button>

--- a/resources/views/tester/objectdiff.blade.php
+++ b/resources/views/tester/objectdiff.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.app', ['title' =>  __('text.testobject') . ' ' . $testobject->name, 'active' => 'tester'])
+
+@section('content')
+    @vite(['resources/css/diff-table.css'])
+    @livewire('testobject-diff', ['testobject' => $testobject])
+@endsection
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,6 +72,10 @@ foreach (['de', 'en'] as $locale) {
                     TesterController::class,
                     "testobject",
                 ])->name("testerObject");
+                Route::get("/tester/testobject/{id}/diff", [
+                    TesterController::class,
+                    "testerObjectDiff",
+                ])->name("testerObject");
                 Route::get("/tester/testrun/{id}", [
                     TesterController::class,
                     "testrun",


### PR DESCRIPTION
## Summary
- add `sitemaps` json column to `testobject`
- allow storing sitemap URLs and running them
- parse sitemap urls in new crawler util methods
- expose new controls in the testobject view
- update translations

## Testing
- `php artisan test` *(fails: could not find driver)*