### PR TITLE
Switch fetch progress tracking to cache

### DIFF
--- a/app/Livewire/Testobject.php
+++ b/app/Livewire/Testobject.php
@@ -123,6 +123,7 @@ class Testobject extends Component
             $objectId = $this->testobject->id;
             Cache::put("fetch-total-{$objectId}", $dispatchedCount);
             Cache::forget("fetch-completed-{$objectId}");
+            Cache::set("fetch-completed-{$objectId}", 0);
 
             $this->updateFetchStatus();
             session()->flash('message', __('text.fetch_started'));


### PR DESCRIPTION
## Summary
- switch `FetchTestrunJob` to use cache counters
- persist fetch progress in cache from the Testobject component
- read fetch progress from cache instead of JSON files

## Testing
- `php artisan test` *(fails: could not find driver)*