### PR TITLE
Add alt text translations

### DIFF
--- a/lang/de/alt.php
+++ b/lang/de/alt.php
@@ -11,5 +11,18 @@ return [
     'open_menu' => 'Menü öffnen',
     'close_menu' => 'Menü schließen',
     'send' => 'Senden',
+    'add' => 'Hinzufügen',
+    'back' => 'Zurück',
+    'close' => 'Schließen',
+    'delete' => 'Löschen',
+    'edit' => 'Bearbeiten',
+    'view' => 'Ansehen',
+    'download' => 'Herunterladen',
+    'sync' => 'Laden',
+    'save' => 'Speichern',
+    'link' => 'Link',
+    'shuffle' => 'Mischen',
+    'login' => 'Anmelden',
+    'compare' => 'Vergleichen',
 ];
 

--- a/lang/en/alt.php
+++ b/lang/en/alt.php
@@ -11,5 +11,18 @@ return [
     'open_menu' => 'Open Menu',
     'close_menu' => 'Close Menu',
     'send' => 'Send',
+    'add' => 'Add',
+    'back' => 'Back',
+    'close' => 'Close',
+    'delete' => 'Delete',
+    'edit' => 'Edit',
+    'view' => 'View',
+    'download' => 'Download',
+    'sync' => 'Loading',
+    'save' => 'Save',
+    'link' => 'Link',
+    'shuffle' => 'Shuffle',
+    'login' => 'Login',
+    'compare' => 'Compare',
 ];
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -6,10 +6,10 @@
     <div class="md:columns-2 columns-1 md:mb-8 mb-0" id="portfolio">
         <!-- Card: Contact -->
         <div class="w-full rounded overflow-hidden shadow-lg mt-4 md:mt-0 home-card-left">
-            <a alt="" href="{{ url(Config::get('app.locale') . '/' . __('url.contact')) }}" wire:navigate.hover >
+            <a alt="{{ __('text.contact') }}" href="{{ url(Config::get('app.locale') . '/' . __('url.contact')) }}" wire:navigate.hover >
                 <div class="relative h-0 pb-44">
                     <img class="absolute top-0 left-0 w-full h-44 object-cover" loading="lazy"
-                         src="{{ Vite::asset('resources/images/kontakt.jpg') }}" alt="">
+                         src="{{ Vite::asset('resources/images/kontakt.jpg') }}" alt="{{ __('text.contact') }}">
                 </div>
                 <div class="px-6 py-4 bg-primary-dark text-white dark:bg-primary">
                     <div class="font-bold text-xl mb-2">
@@ -24,10 +24,10 @@
 
         <!-- Card: Portfolio -->
         <div class="w-full rounded overflow-hidden shadow-lg mt-4 md:mt-0 home-card-right">
-            <a alt="" href="{{ url(Config::get('app.locale') . '/' . __('url.cv')) }}" wire:navigate.hover >
+            <a alt="{{ __('text.cv') }}" href="{{ url(Config::get('app.locale') . '/' . __('url.cv')) }}" wire:navigate.hover >
                 <div class="relative h-0 pb-44">
                     <img class="absolute top-0 left-0 w-full h-44 object-cover" loading="lazy"
-                         src="{{ Vite::asset('resources/images/portfolio.jpg') }}" alt="">
+                         src="{{ Vite::asset('resources/images/portfolio.jpg') }}" alt="{{ __('text.cv') }}">
                 </div>
                 <div class="px-6 py-4 bg-primary-dark text-white dark:bg-primary">
                     <div class="font-bold text-xl mb-2">
@@ -43,10 +43,10 @@
 
     <div class="md:columns-2 columns-1 md:mb-8 md-0" id="portfolio">
         <div class="w-full rounded overflow-hidden shadow-lg mt-4 md:mt-0 home-card-left">
-            <a alt="" href="{{ url(Config::get('app.locale') . '/' . __('url.tester')) }}" wire:navigate.hover >
+            <a alt="{{ __('text.tester') }}" href="{{ url(Config::get('app.locale') . '/' . __('url.tester')) }}" wire:navigate.hover >
                 <div class="relative h-0 pb-44">
                     <img class="absolute top-0 left-0 w-full h-44 object-cover" loading="lazy"
-                         src="{{ Vite::asset('resources/images/testing.jpg') }}" alt="">
+                         src="{{ Vite::asset('resources/images/testing.jpg') }}" alt="{{ __('text.tester') }}">
                 </div>
                 <div class="px-6 py-4 bg-primary-dark text-white dark:bg-primary">
                     <div class="font-bold text-xl mb-2 ">
@@ -59,10 +59,10 @@
             </a>
         </div>
         <div class="w-full rounded overflow-hidden shadow-lg mt-4 md:mt-0 home-card-right">
-            <a alt="" href="{{ url(Config::get('app.locale') . '/' . __('url.teams')) }}" wire:navigate.hover >
+            <a alt="{{ __('text.random-teams') }}" href="{{ url(Config::get('app.locale') . '/' . __('url.teams')) }}" wire:navigate.hover >
                 <div class="relative h-0 pb-44">
                     <img class="absolute top-0 left-0 w-full h-44 object-cover" loading="lazy"
-                         src="{{ Vite::asset('resources/images/random.jpg') }}" alt="">
+                         src="{{ Vite::asset('resources/images/random.jpg') }}" alt="{{ __('text.random-teams') }}">
                 </div>
                 <div class="px-6 py-4 bg-primary-dark text-white dark:bg-primary">
                     <div class="font-bold text-xl mb-2">
@@ -79,10 +79,10 @@
     <div class="md:columns-2 columns-1 md:mb-8 md-0" id="portfolio">
         <!-- Card: Private Tools -->
         <div class="w-full rounded overflow-hidden shadow-lg mt-4 md:mt-0 home-card-left">
-            <a alt="" href="{{ url(Config::get('app.locale') . '/' . __('url.account')) }}" wire:navigate.hover >
+            <a alt="{{ __('text.account') }}" href="{{ url(Config::get('app.locale') . '/' . __('url.account')) }}" wire:navigate.hover >
                 <div class="relative h-0 pb-44">
                     <img class="absolute top-0 left-0 w-full h-44 object-cover" loading="lazy"
-                         src="{{ Vite::asset('resources/images/private.jpg') }}" alt="">
+                         src="{{ Vite::asset('resources/images/private.jpg') }}" alt="{{ __('text.account') }}">
                 </div>
                 <div class="px-6 py-4 bg-primary-dark text-white dark:bg-primary">
                     <div class="font-bold text-xl mb-2">
@@ -97,14 +97,14 @@
 
         <!-- Card: Imprint & Data Protection -->
         <div class="w-full rounded overflow-hidden shadow-lg mt-4 md:mt-0 home-card-right">
-            <a alt="" href="{{ url(Config::get('app.locale') . '/' . __('url.imprint')) }}" wire:navigate.hover >
+            <a alt="{{ __('text.imprint') }}" href="{{ url(Config::get('app.locale') . '/' . __('url.imprint')) }}" wire:navigate.hover >
                 <div class="relative h-0 pb-44">
                     <img class="absolute top-0 left-0 w-full h-44 object-cover" loading="lazy"
-                         src="{{ Vite::asset('resources/images/law.jpg') }}" alt="">
+                         src="{{ Vite::asset('resources/images/law.jpg') }}" alt="{{ __('text.imprint') }}">
                 </div>
                 <div class="px-6 py-4 bg-primary-dark text-white dark:bg-primary">
                     <div class="font-bold text-xl mb-2">
-                        <a alt="" href="{{ url(Config::get('app.locale') . '/' . __('url.imprint')) }}">{{ __('text.imprint') }}</a> {{ __('text.and') }} <a alt="" href="{{ url(Config::get('app.locale') . '/' . __('url.data-protection')) }}">{{ __('text.data-protection') }}</a>
+                        <a alt="{{ __('text.imprint') }}" href="{{ url(Config::get('app.locale') . '/' . __('url.imprint')) }}">{{ __('text.imprint') }}</a> {{ __('text.and') }} <a alt="{{ __('text.data-protection') }}" href="{{ url(Config::get('app.locale') . '/' . __('url.data-protection')) }}">{{ __('text.data-protection') }}</a>
                     </div>
                 </div>
             </a>

--- a/resources/views/livewire/account.blade.php
+++ b/resources/views/livewire/account.blade.php
@@ -37,7 +37,7 @@
             </div>
             <div class="mt-3 flex gap-4 items-center">
                 <button class="btn" wire:click="saveAccount">{{ __('text.save') }}</button>
-                <a alt="" wire:click="cancelEdit" class="flex items-center gap-2 py-auto hover:cursor-grab btn-back dark:invert dark:text-secondary-dark">
+                <a alt="{{ __('text.back') }}" wire:click="cancelEdit" class="flex items-center gap-2 py-auto hover:cursor-grab btn-back dark:invert dark:text-secondary-dark">
                     <img class="w-4" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}" alt="Back Icon" />
                     <span class="leading-none">{{ __('text.back') }}</span>
                 </a>

--- a/resources/views/livewire/notes.blade.php
+++ b/resources/views/livewire/notes.blade.php
@@ -6,10 +6,10 @@
             @endforeach
         </select>
         <button wire:click="addNote" class="ml-2 btn btn-details" id="add-note">
-            <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt=""/>
+            <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt="{{ __('alt.add') }}"/>
         </button>
         <button wire:click="deleteNote" wire:confirm="{{ __('text.are-you-sure') }}" class="ml-2 btn btn-delete" id="delete-note">
-            <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}"  alt=""/>
+            <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}"  alt="{{ __('alt.close') }}"/>
         </button>
     </div>
     <br>
@@ -26,7 +26,7 @@
                     </label>
                 </div>
                 <button data-copy="true" data-text="{{ $selectedNote->getPublicUrl() }}" class="{{ $selectedNote->share ? '' : 'hidden' }} ml-2 btn btn-diff" id="add-note">
-                    <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/link-outline.svg') }}"  alt=""/>
+                    <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/link-outline.svg') }}"  alt="{{ __('alt.link') }}"/>
                 </button>
             </div>
         </div>

--- a/resources/views/livewire/portfolio-edit.blade.php
+++ b/resources/views/livewire/portfolio-edit.blade.php
@@ -1,6 +1,6 @@
 <div>
     <button wire:click="addPortfolio" class="btn" id="add-note">
-        <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}" alt="" />
+        <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}" alt="{{ __('alt.add') }}" />
     </button>
 
     @if (!$activePortfolio)
@@ -9,18 +9,18 @@
                 <span>{{ $portfolio->name }}</span>
                 <div class="grid md:grid-cols-2 gap-5 mt-2">
                     <button wire:click="deletePortfolio({{ $portfolio->id }})" wire:confirm="{{ __('text.are-you-sure') }}" class="btn-delete" id="delete-redirect" data-id="{{ $portfolio->id }}">
-                        <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}" alt="" />
+                        <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}" alt="{{ __('alt.close') }}" />
                     </button>
                     <button wire:click="editPortfolio({{ $portfolio->id }})" id="{{ $portfolio->id }}" class="btn btn-edit">
-                        <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/pencil-outline.svg') }}" alt="" />
+                        <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/pencil-outline.svg') }}" alt="{{ __('alt.edit') }}" />
                     </button>
                 </div>
             </div>
         @endforeach
     @else
     <div class="mt-3">
-        <a alt="" wire:click="cancelEdit" class="flex gap-2 mb-4 align-center hover:cursor-pointer btn-back">
-            <img class="w-4 dark:invert" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}" alt="" />
+        <a alt="{{ __('text.back') }}" wire:click="cancelEdit" class="flex gap-2 mb-4 align-center hover:cursor-pointer btn-back">
+            <img class="w-4 dark:invert" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}" alt="{{ __('alt.back') }}" />
             <span class="leading-none">
                 {{__('text.back')}}
             </span>
@@ -51,7 +51,7 @@
                 <div class="my-3 flex flex-wrap gap-3">
                     @foreach ($activePortfolio->media as $photo)
                         <div class="">
-                            <img class="w-24 h-24 object-cover rounded border" src="{{ Storage::url($photo->path) }}" alt="">
+                            <img class="w-24 h-24 object-cover rounded border" src="{{ Storage::url($photo->path) }}" alt="{{ $photo->name ?? '' }}">
                             <button class="btn mt-3 w-full btn-delete" id="{{ $photo->id }}" wire:click="deleteMedia($event.target.id)" wire:confirm="Are you sure?">{{ __('text.delete') }}</button>
                         </div>
                     @endforeach
@@ -66,7 +66,7 @@
                     <div class="my-3 flex flex-wrap gap-3">
                     @foreach ($media as $photo)
                         @if (in_array($photo->getMimeType(), ['image/jpeg', 'image/png', 'image/gif']))
-                            <img class="w-24 h-24 object-cover rounded border" src="{{ $photo->temporaryUrl() }}" alt="">
+                            <img class="w-24 h-24 object-cover rounded border" src="{{ $photo->temporaryUrl() }}" alt="{{ __('alt.view') }}">
                         @endif
                     @endforeach
                     </div>

--- a/resources/views/livewire/portfolio.blade.php
+++ b/resources/views/livewire/portfolio.blade.php
@@ -6,11 +6,11 @@
             @if ($user->portfolios->count() > 0)
             <li>
                 @if (($selectedUser ? $selectedUser->id : null) == $user->id)
-                <a alt="" href="#" class="px-4 py-3 rounded-lg w-full ibtn active" aria-current="page">
+                <a alt="{{ $user->name }}" href="#" class="px-4 py-3 rounded-lg w-full ibtn active" aria-current="page">
                     {{ $user->name }}
                 </a>
                 @else
-                <a alt="" href="#" class="px-4 py-3 rounded-lg w-full ibtn" wire:click="selectUser($event.target.id)" id="{{ $user->id }}" >
+                <a alt="{{ $user->name }}" href="#" class="px-4 py-3 rounded-lg w-full ibtn" wire:click="selectUser($event.target.id)" id="{{ $user->id }}" >
                     {{ $user->name }}
                 </a>
                 @endif
@@ -24,10 +24,10 @@
                 @foreach ($portfolios as $portfolio)
                 @foreach ($portfolio as $item)
                 <div class="max-w-lg w-full rounded overflow-hidden shadow-lg transform transition duration-300 hover:scale-105 hover:shadow-2xl">
-                    <a alt="" href="{{ $item->url }}" target="_blank">
+                    <a alt="{{ $item->name }}" href="{{ $item->url }}" target="_blank">
                         @if ($item->media && count($item->media) > 0)
                         <div class="relative h-0 pb-56 overflow-hidden">
-                            <img class="absolute inset-0 w-full h-full object-cover" loading="lazy" src="{{ Storage::url($item->media[0]->path) }}" alt="">
+                            <img class="absolute inset-0 w-full h-full object-cover" loading="lazy" src="{{ Storage::url($item->media[0]->path) }}" alt="{{ $item->name }}">
                         </div>
                         @endif
                         <div class="px-6 py-4">
@@ -43,7 +43,7 @@
 
             <div class="mb-5">
                 @if ($selectedUser)
-                <a alt="" wire:navigate.hover class="btn w-fit" href="{{ url(Config::get('app.locale') . '/' . __('url.contact')) }}/{{ $selectedUser->email }}" >{{ __('text.contact') }}</a>
+                <a alt="{{ __('text.contact') }}" wire:navigate.hover class="btn w-fit" href="{{ url(Config::get('app.locale') . '/' . __('url.contact')) }}/{{ $selectedUser->email }}" >{{ __('text.contact') }}</a>
                 @endif
             </div>
         </div>

--- a/resources/views/livewire/random-teams.blade.php
+++ b/resources/views/livewire/random-teams.blade.php
@@ -1,7 +1,7 @@
 <div>
     <h2>{{ __('text.players') }}</h2>
-    <a alt="" wire:click="newPlayer" wire:loading.class="opacity-50" class="btn md:w-1/3">
-        <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt=""/>
+    <a alt="{{ __('alt.add') }}" wire:click="newPlayer" wire:loading.class="opacity-50" class="btn md:w-1/3">
+        <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt="{{ __('alt.add') }}"/>
     </a>
 
     @foreach ($players as $key => $player)
@@ -9,7 +9,7 @@
             <div class="flex justify-between gap-4">
                 <input type="text" wire:change="updatePlayerName($event.target.value, $event.target.id)" id="{{ $key }}" class="w-full rounded dark:bg-secondary-light" value="{{ $player }}" placeholder="{{ empty($player) ? __('text.player-name') : ''}}" />
                 <button class="btn btn-delete" id="{{ $key }}" wire:click="deletePlayer($event.target.id)" wire:confirm="{{ __('text.are-you-sure') }}">
-                    <img class="w-6 h-6 invert" src="{{ Vite::asset('resources/icons/close.svg') }}"  alt=""/>
+                    <img class="w-6 h-6 invert" src="{{ Vite::asset('resources/icons/close.svg') }}"  alt="{{ __('alt.close') }}"/>
                 </button>
             </div>
         </div>
@@ -17,8 +17,8 @@
 
     <p class="mt-3 text-lg">{{ __('text.number-of-teams') }}</p>
     <input type="number" class="rounded dark:bg-secondary-light" value="{{ $numberOfTeams }}" wire:change="updateNumberOfTeams($event.target.value)"/>
-    <a alt="" wire:click="generateTeams" wire:loading.class="opacity-50" class="btn btn-secondary mt-3 md:w-1/3">
-        <img class="w-6 h-5 invert dark:invert-0" src="{{ Vite::asset('resources/icons/shuffle.svg') }}"  alt=""/>
+    <a alt="{{ __('alt.shuffle') }}" wire:click="generateTeams" wire:loading.class="opacity-50" class="btn btn-secondary mt-3 md:w-1/3">
+        <img class="w-6 h-5 invert dark:invert-0" src="{{ Vite::asset('resources/icons/shuffle.svg') }}"  alt="{{ __('alt.shuffle') }}"/>
     </a>
 
     @if (count($teams) > 0)

--- a/resources/views/livewire/redirects.blade.php
+++ b/resources/views/livewire/redirects.blade.php
@@ -1,6 +1,6 @@
 <div>
     <button wire:click="addRedirect" class="btn" id="add-redirect">
-        <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt=""/>
+        <img class="w-6 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt="{{ __('alt.add') }}"/>
     </button>
     <div class="mt-3 w-full" id="redirects-wrapper">
         @foreach ($redirects ?? [] as $redirect)
@@ -28,10 +28,10 @@
                         </div>
                         <div class="flex justify-end gap-3 mt-3">
                             <button type="button" wire:click="cancelEdit" class="btn btn-delete">
-                                <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}"  alt=""/>
+                                <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}"  alt="{{ __('alt.close') }}"/>
                             </button>
                             <button type="submit" class="btn btn-fetch">
-                                <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/save-outline.svg') }}"  alt=""/>
+                                <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/save-outline.svg') }}"  alt="{{ __('alt.save') }}"/>
                             </button>
                         </div>
                     </form>
@@ -74,13 +74,13 @@
                     </div>
                     <div class="grid grid-cols-3 gap-5 mt-2">
                         <button wire:click="deleteRedirect({{ $redirect->id }})" wire:confirm="{{ __('text.are-you-sure') }}" class="btn btn-delete" id="delete-redirect" data-id="{{ $redirect->id }}">
-                            <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}"  alt=""/>
+                            <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}"  alt="{{ __('alt.close') }}"/>
                         </button>
                         <button wire:click="editRedirect({{ $redirect->id }})" id="e-{{ $redirect->id }}" class="btn btn-edit">
-                            <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/pencil-outline.svg') }}"  alt=""/>
+                            <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/pencil-outline.svg') }}"  alt="{{ __('alt.edit') }}"/>
                         </button>
                         <button data-copy="true" data-text="{{ $redirect->url }}" class="btn btn-diff">
-                            <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/link-outline.svg') }}"  alt=""/>
+                            <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/link-outline.svg') }}"  alt="{{ __('alt.link') }}"/>
                         </button>
                     </div>
                 @endif

--- a/resources/views/livewire/testobject-diff.blade.php
+++ b/resources/views/livewire/testobject-diff.blade.php
@@ -36,13 +36,13 @@
     </div>
     <button class="btn mb-3" wire:click="updateDiff">
         <span wire:loading.remove wire:target="updateDiff">{{ __('text.compare') }}</span>
-        <img wire:loading wire:target="updateDiff" class="w-4 h-4 m-auto animate-spin invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt=""/>
+        <img wire:loading wire:target="updateDiff" class="w-4 h-4 m-auto animate-spin invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt="{{ __('alt.sync') }}"/>
     </button>
 
     @foreach ($diffs as $runId => $data)
     <div class="border p-3 mb-4 pb-3 rounded border-primary-dark dark:border-primary-light">
         <h3 id="{{ $data['run']->name }}">
-            <a alt="" href="#{{ $data['run']->name }}">
+            <a alt="{{ __('text.testrun') }}" href="#{{ $data['run']->name }}">
                 {{ $data['run']->name }} ({{ $data['run']->testinstances->count() }})
             </a>
         </h3>

--- a/resources/views/livewire/testobject.blade.php
+++ b/resources/views/livewire/testobject.blade.php
@@ -1,6 +1,6 @@
 <div>
-    <a alt="" wire:navigate.hover href="{{url(Config::get('app.locale') ."/tester/")}}" class="flex gap-2 mb-4 align-center btn-back dark:invert dark:text-secondary-dark">
-        <img class="w-4" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}"  alt=""/>
+    <a alt="{{ __('text.back') }}" wire:navigate.hover href="{{url(Config::get('app.locale') ."/tester/")}}" class="flex gap-2 mb-4 align-center btn-back dark:invert dark:text-secondary-dark">
+        <img class="w-4" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}"  alt="{{ __('alt.back') }}"/>
         <span class="leading-none">
             {{__('text.back')}}
         </span>
@@ -16,7 +16,7 @@
     </select>
 
     <button class="btn mb-3" wire:click="createRun">
-        <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt=""/>
+        <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt="{{ __('alt.add') }}"/>
     </button>
 
     <div class="mb-3">
@@ -25,11 +25,11 @@
         <div class="grid grid-cols-2 gap-5">
             <button class="btn" wire:click="runSitemaps" wire:loading.attr="disabled" wire:target="runSitemaps">
                 <span wire:loading.remove wire:target="runSitemaps">{{ __('text.run_sitemaps') }}</span>
-                <img wire:loading wire:target="runSitemaps" class="w-4 h-4 m-auto animate-spin invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt=""/>
+                <img wire:loading wire:target="runSitemaps" class="w-4 h-4 m-auto animate-spin invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt="{{ __('alt.sync') }}"/>
             </button>
             <button class="btn" wire:click="fetchAll">
                 <span wire:loading.remove wire:target="fetchAll">{{ __('text.fetch_all') }}</span>
-                <img wire:loading wire:target="fetchAll" class="w-4 h-4 m-auto animate-spin invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt=""/>
+                <img wire:loading wire:target="fetchAll" class="w-4 h-4 m-auto animate-spin invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt="{{ __('alt.sync') }}"/>
             </button>
         </div>
         @if ($fetchStatus)
@@ -38,12 +38,12 @@
             </div>
         @endif
     </div>
-    <a alt="" class="btn mb-3 w-fit" href="{{url(Config::get('app.locale') . "/tester/testobject/{$testobject->id}/diff")}}">
+    <a alt="{{ __('alt.compare') }}" class="btn mb-3 w-fit" href="{{url(Config::get('app.locale') . "/tester/testobject/{$testobject->id}/diff")}}">
         {{ __('text.bulk_diff') }}
     </a>
     <button class="btn mb-3" wire:click="deleteAll">
         <span wire:loading.remove wire:target="deleteAll">{{ __('text.delete_all') }}</span>
-        <img wire:loading wire:target="deleteAll" class="w-4 h-4 m-auto animate-spin invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt=""/>
+        <img wire:loading wire:target="deleteAll" class="w-4 h-4 m-auto animate-spin invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt="{{ __('alt.sync') }}"/>
     </button>
 
     <p>{{ count($testobject->testruns) }} Testruns</p>
@@ -56,10 +56,10 @@
 
             <div class="grid grid-cols-3 sm:grid-cols-5 gap-3 align-middle">
                 <button class="btn btn-delete" wire:click="deleteRun({{$testrun->id}})" wire:confirm="Are you sure?">
-                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}"  alt=""/>
+                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}"  alt="{{ __('alt.delete') }}"/>
                 </button>
-                <a alt="" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testrun/{$testrun->id}")}}" >
-                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/eye.svg') }}"  alt=""/>
+                <a alt="{{ __('alt.view') }}" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testrun/{$testrun->id}")}}" >
+                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/eye.svg') }}"  alt="{{ __('alt.view') }}"/>
                 </a>
             </div>
         </div>

--- a/resources/views/livewire/testobjects.blade.php
+++ b/resources/views/livewire/testobjects.blade.php
@@ -24,7 +24,7 @@
                     'livewire' => true
                 ])
                 <button type="submit" class="btn">
-                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt=""/>
+                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt="{{ __('alt.add') }}"/>
                 </button>
             </form>
         </div>
@@ -57,7 +57,7 @@
                     'value' => $url
                 ])
                 <button type="submit" class="btn btn-edit">
-                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt=""/>
+                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt="{{ __('alt.sync') }}"/>
                 </button>
             </form>
         </div>
@@ -71,13 +71,13 @@
 
             <div class="grid grid-cols-3 sm:grid-cols-5 gap-3 align-middle">
                 <button class="btn btn-delete" wire:click="deleteObject({{ $testObj->id }})" wire:confirm="Are you sure?">
-                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}"  alt=""/>
+                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}"  alt="{{ __('alt.delete') }}"/>
                 </button>
                 <button class="btn btn-edit" wire:click="editObject({{ $testObj->id }})">
-                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt=""/>
+                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt="{{ __('alt.sync') }}"/>
                 </button>
-                <a alt="" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testobject/{$testObj->id}")}}">
-                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/eye.svg') }}"  alt=""/>
+                <a alt="{{ __('alt.view') }}" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testobject/{$testObj->id}")}}">
+                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/eye.svg') }}"  alt="{{ __('alt.view') }}"/>
                 </a>
             </div>
         </div>

--- a/resources/views/livewire/testrun.blade.php
+++ b/resources/views/livewire/testrun.blade.php
@@ -1,8 +1,8 @@
 <div>
     @vite(['resources/css/diff-table.css'])
 
-    <a alt="" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testobject/{$testrun->testobject->id}")}}" class="flex gap-2 mb-4 align-center btn-back dark:text-secondary-dark dark:invert">
-        <img class="w-4" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}" alt="" />
+    <a alt="{{ __('text.back') }}" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testobject/{$testrun->testobject->id}")}}" class="flex gap-2 mb-4 align-center btn-back dark:text-secondary-dark dark:invert">
+        <img class="w-4" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}" alt="{{ __('alt.back') }}" />
         <span class="leading-none">
             {{__('text.back')}}
         </span>
@@ -38,7 +38,7 @@
                     </div>
                     <div class="grid-cols-2 grid align-middle gap-5 mb-3">
                         <button type="submit" class="btn">
-                            <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/git-compare.svg') }}" alt="" />
+                            <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/git-compare.svg') }}" alt="{{ __('alt.compare') }}" />
                         </button>
                     </div>
                 </form>
@@ -64,8 +64,8 @@
     ])
 
     <button class="btn mb-3" wire:click="createInstance" wire:loading.attr="disabled" wire:target="createInstance">
-        <img wire:loading.remove wire:target="createInstance" class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}" alt="" />
-        <img wire:loading wire:target="createInstance" class="w-4 h-4 invert animate-spin" src="{{ Vite::asset('resources/icons/sync.svg') }}" alt="" />
+        <img wire:loading.remove wire:target="createInstance" class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}" alt="{{ __('alt.add') }}" />
+        <img wire:loading wire:target="createInstance" class="w-4 h-4 invert animate-spin" src="{{ Vite::asset('resources/icons/sync.svg') }}" alt="{{ __('alt.sync') }}" />
     </button>
 
     @foreach ($testrun->testinstances as $testinstance)
@@ -75,20 +75,20 @@
 
             <div class="grid grid-cols-3 sm:grid-cols-5 gap-3 align-middle">
                 <button class="btn btn-delete" wire:click="deleteInstance({{$testinstance->id}})" wire:confirm="Are you sure?">
-                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}" alt="" />
+                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}" alt="{{ __('alt.delete') }}" />
                 </button>
-                <a alt="" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testinstance/{$testinstance->id}")}}" >
-                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/eye.svg') }}" alt="" />
+                <a alt="{{ __('alt.view') }}" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testinstance/{$testinstance->id}")}}" >
+                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/eye.svg') }}" alt="{{ __('alt.view') }}" />
                 </a>
                 <button class="btn btn-fetch" wire:navigate wire:click="fetchInstance({{$testinstance->id}})"")}}" >
                     <img
                         class="w-20 h-5 invert"
                         src="{{ Vite::asset('resources/icons/' . (empty($testinstance->html) ? 'download.svg' : 'arrow-down.svg')) }}"
-                        alt=""
+                        alt="{{ __('alt.download') }}"
                     />
                 </button>
                 <button class="btn btn-diff" wire:click="addToDiff({{$testinstance->id}})">
-                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/git-compare.svg') }}" alt="" />
+                    <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/git-compare.svg') }}" alt="{{ __('alt.compare') }}" />
                 </button>
             </div>
         </div>

--- a/resources/views/livewire/timetrack-edit-single.blade.php
+++ b/resources/views/livewire/timetrack-edit-single.blade.php
@@ -1,6 +1,6 @@
 <div>
-    <a alt="" wire:navigate.hover href="{{url(Config::get('app.locale') . '/' . __('url.account') . '/' . __('url.timetracking'))}}" class="flex gap-2 mb-4 align-center btn-back dark:text-secondary-dark dark:invert">
-        <img class="w-4" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}"  alt=""/>
+    <a alt="{{ __('text.back') }}" wire:navigate.hover href="{{url(Config::get('app.locale') . '/' . __('url.account') . '/' . __('url.timetracking'))}}" class="flex gap-2 mb-4 align-center btn-back dark:text-secondary-dark dark:invert">
+        <img class="w-4" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}"  alt="{{ __('alt.back') }}"/>
         <span class="leading-none">
             {{__('text.back')}}
         </span>
@@ -53,7 +53,7 @@
     </button>
 
     <button class="btn" wire:click="updateTimetrack">
-        <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt=""/>
+        <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt="{{ __('alt.sync') }}"/>
     </button>
 
     <div class="mt-3">

--- a/resources/views/livewire/timetrack-edit.blade.php
+++ b/resources/views/livewire/timetrack-edit.blade.php
@@ -1,20 +1,20 @@
 <div>
     <button class="btn mb-3" wire:click="createTimetrack">
-        <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt=""/>
+        <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/add.svg') }}"  alt="{{ __('alt.add') }}"/>
     </button>
 
     @foreach ($timetracks as $timetrack)
     <div class="border px-3 mb-4 pb-3 rounded border-primary-dark dark:border-primary-light">
         <p>{{ $timetrack->title }}</p>
         <div class="grid grid-cols-3 sm:grid-cols-5 gap-3 align-middle">
-            <a alt="" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . '/' . __('url.account') . '/' . __('url.timetracking') . '/' . $timetrack->id)}}" >
-                <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/eye.svg') }}"  alt=""/>
+            <a alt="{{ __('alt.view') }}" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . '/' . __('url.account') . '/' . __('url.timetracking') . '/' . $timetrack->id)}}" >
+                <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/eye.svg') }}"  alt="{{ __('alt.view') }}"/>
             </a>
             <button data-copy="true" data-text="{{url(Config::get('app.locale') . '/' . __('url.timetracking') . '/' . $timetrack->id)}}" class="justify-center w-full p-2 py-2.5 px-4 bg-blue-500 text-white rounded hover:bg-blue-700 flex items-center edit-redirect">
-                <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/link-outline.svg') }}"  alt=""/>
+                <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/link-outline.svg') }}"  alt="{{ __('alt.link') }}"/>
             </button>
             <button class="btn btn-delete" wire:click="deleteTimetrack({{$timetrack->id}})" wire:confirm="Are you sure?">
-                <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}"  alt=""/>
+                <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}"  alt="{{ __('alt.delete') }}"/>
             </button>
         </div>
     </div>

--- a/resources/views/livewire/timetrack.blade.php
+++ b/resources/views/livewire/timetrack.blade.php
@@ -22,7 +22,7 @@
         <div class="grid grid-cols-3 gap-x-6 items-baseline border p-2 text-base rounded">
         <div class="truncate">
             @if (isset($row['link']) && $row['link'])
-                <a alt="" href="{{ $row['link'] }}" target="_blank" class="text-blue-500 hover:underline">
+                <a alt="{{ __('alt.link') }}" href="{{ $row['link'] }}" target="_blank" class="text-blue-500 hover:underline">
             @endif
             {{ $row['title'] }}
             @if (isset($row['link']) && $row['link'])

--- a/resources/views/rt-share/index.blade.php
+++ b/resources/views/rt-share/index.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <h1>{{ __('text.rt-share') }}</h1>
 <p>{!! __('descriptions.rt-share') !!}</p>
-<a alt="" class="btn btn-primary w-fit mb-3 flex items-center gap-2" href="https://github.com/Hans2711/rt-share" target="_blank">
+<a alt="{{ __('alt.github') }}" class="btn btn-primary w-fit mb-3 flex items-center gap-2" href="https://github.com/Hans2711/rt-share" target="_blank">
     <img class="w-6 h-6 invert" src="{{ Vite::asset('resources/icons/github.svg') }}" alt="GitHub" />
     Github
 </a>

--- a/resources/views/tester/auth.blade.php
+++ b/resources/views/tester/auth.blade.php
@@ -13,7 +13,7 @@
         </div>
         <div class="flex items-center justify-between">
             <button class="btn" type="submit">
-                <img class="w-20 h-6 invert" src="{{ Vite::asset('resources/icons/lock-open.svg') }}"  alt=""/>
+                <img class="w-20 h-6 invert" src="{{ Vite::asset('resources/icons/lock-open.svg') }}"  alt="{{ __('alt.login') }}"/>
             </button>
         </div>
     </form>

--- a/resources/views/tester/diff.blade.php
+++ b/resources/views/tester/diff.blade.php
@@ -6,7 +6,7 @@
     @if (isset($error))
         <div class="alert alert-danger">{{ $error }}</div>
     @else
-        <h1>Diff: <a alt="" href="{{$testobject->url}}" class="underline">{{$testobject->name}} {{$testrun->name}}</a> ({{$testrun->created_at}})</h1>
+        <h1>Diff: <a alt="{{ __('text.testobject') }}" href="{{$testobject->url}}" class="underline">{{$testobject->name}} {{$testrun->name}}</a> ({{$testrun->created_at}})</h1>
         {!! $diff !!}
     @endif
 @endsection

--- a/resources/views/tester/instance.blade.php
+++ b/resources/views/tester/instance.blade.php
@@ -2,8 +2,8 @@
 
 @section('content')
     <h1>{{ __('text.testinstance') }} {{$instance->created_at_clean}}</h1>
-    <a alt="" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testrun/{$instance->testrun->id}")}}" class="flex gap-2 mb-4 align-center btn-back dark:text-secondary-dark dark:invert">
-        <img class="w-4" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}"  alt=""/>
+    <a alt="{{ __('text.back') }}" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testrun/{$instance->testrun->id}")}}" class="flex gap-2 mb-4 align-center btn-back dark:text-secondary-dark dark:invert">
+        <img class="w-4" src="{{ Vite::asset('resources/icons/chevron-back.svg') }}"  alt="{{ __('alt.back') }}"/>
         <span class="leading-none">
             {{__('text.back')}}
         </span>


### PR DESCRIPTION
## Summary
- add translations for alt text
- fill alt attributes in various Blade templates

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683ba5936c5883208d25a330234a781c