### PR TITLE
Preload app.css in layout

### DIFF
--- a/resources/views/global/head/app-css-preload.blade.php
+++ b/resources/views/global/head/app-css-preload.blade.php
@@ -1,0 +1,1 @@
+<link rel="preload" href="{{ Vite::asset('resources/css/app.css') }}" as="style">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,6 +10,7 @@
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
         @include('global.head.font-preload')
+        @include('global.head.app-css-preload')
         @include('global.head.title', ['title' => $title ?? null])
         @include('global.head.og-tags', ['title' => $title ?? null, 'description' => $description ?? null])
 


### PR DESCRIPTION
## Summary
- preload app.css with a new head partial
- include the CSS preload partial in the main layout

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683dd16ebb108320a0901cf2462ed6a5