### PR TITLE
Add caching to IP geolocation lookups

### DIFF
--- a/app/Utilities/IpGeoUtility.php
+++ b/app/Utilities/IpGeoUtility.php
@@ -1,14 +1,17 @@
 <?php
 namespace App\Utilities;
 
+use Illuminate\Support\Facades\Cache;
+
 class IpGeoUtility
 {
-    public static function getGeo($ip) {
-        $url = "http://ip-api.com/json/$ip";
-        $response = file_get_contents($url);
-        $data = json_decode($response);
-        return $data;
+    public static function getGeo($ip)
+    {
+        return Cache::rememberForever("ip-geo-{$ip}", function () use ($ip) {
+            $url = "http://ip-api.com/json/{$ip}";
+            $response = file_get_contents($url);
+            return json_decode($response);
+        });
     }
-
 }
 


### PR DESCRIPTION
## Summary
- cache results from `IpGeoUtility::getGeo`

## Testing
- `php -l app/Utilities/IpGeoUtility.php` *(fails: `php` not installed)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683dd39fc5b483208d20f4a2bcddb4ed