### PR TITLE
Filter timetracks by authenticated user

### DIFF
--- a/app/Livewire/TimetrackEdit.php
+++ b/app/Livewire/TimetrackEdit.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use App\Models\Timetrack;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 class TimetrackEdit extends Component
@@ -11,12 +12,13 @@ class TimetrackEdit extends Component
 
     public function mount()
     {
-        $this->timetracks = Timetrack::all();
+        $this->timetracks = Timetrack::where('user', Auth::id())->get();
     }
 
     public function createTimetrack()
     {
         $this->timetracks->push(Timetrack::makeInstance('New Timetrack', '[]'));
+        $this->timetracks->last()->user = Auth::id();
         $this->timetracks->last()->save();
     }
 


### PR DESCRIPTION
## Summary
- ensure `TimetrackEdit` only loads timetracks for the logged-in user
- set the user when creating new timetracks

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683dd345677c83209e724c606e1405d3