### PR TITLE
Fix notes mount

### DIFF
--- a/app/Livewire/Notes.php
+++ b/app/Livewire/Notes.php
@@ -74,10 +74,12 @@ class Notes extends Component
     public function mount()
     {
         $this->notes = Auth::user()->notes;
-        if (empty($this->notes)) {
+        if ($this->notes->isEmpty()) {
             $note = new Note();
+            $note->user = Auth::user()->id;
             $note->save();
-            $this->notes = Note::all();
+
+            $this->notes = Auth::user()->notes;
         }
 
         if (session()->has("selectedNote")) {


### PR DESCRIPTION
## Summary
- fix notes mount logic to create a user note and reload using the user relationship

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_683dd32f6e548320a4fc24492277e18f