### PR TITLE
Refactor Livewire click handlers

### DIFF
--- a/resources/views/livewire/account.blade.php
+++ b/resources/views/livewire/account.blade.php
@@ -100,7 +100,7 @@
                         <div class="col-span-2 flex flex-wrap gap-2">
                             @foreach ($permissions as $key => $permission)
                                 <label class="flex items-center text-sm">
-                                    <input type="checkbox" class="mr-1" wire:click="togglePermission('{{ $user->id }}','{{ $key }}')" @checked($user->getPermission($key))>
+                                    <input type="checkbox" class="mr-1" id="{{ $user->id }}" wire:click="togglePermission($event.target.id, '{{ $key }}')" @checked($user->getPermission($key))>
                                     <span>{{ $permission }}</span>
                                 </label>
                             @endforeach

--- a/resources/views/livewire/cv-edit.blade.php
+++ b/resources/views/livewire/cv-edit.blade.php
@@ -19,9 +19,9 @@
                 'additional' => "wire:model='fields.{$index}.content'"
             ])
             <div class="flex gap-2 mt-2">
-                <button type="button" class="btn" wire:click="moveFieldUp({{ $index }})" @if($index === 0) disabled @endif>↑</button>
-                <button type="button" class="btn" wire:click="moveFieldDown({{ $index }})" @if($index === count($fields) - 1) disabled @endif>↓</button>
-                <button type="button" class="btn btn-delete btn-sm" wire:click="removeField({{ $index }})">Remove</button>
+                <button type="button" class="btn" id="{{ $index }}" wire:click="moveFieldUp($event.target.id)" @if($index === 0) disabled @endif>↑</button>
+                <button type="button" class="btn" id="{{ $index }}" wire:click="moveFieldDown($event.target.id)" @if($index === count($fields) - 1) disabled @endif>↓</button>
+                <button type="button" class="btn btn-delete btn-sm" id="{{ $index }}" wire:click="removeField($event.target.id)">Remove</button>
             </div>
         </div>
     @endforeach
@@ -76,21 +76,21 @@
                     </div>
 
                     <div class="flex gap-2 mt-2">
-                        <button type="button" class="btn" wire:click="moveListItemUp({{ $listIndex }}, {{ $itemIndex }})" @if($itemIndex === 0) disabled @endif>↑</button>
-                        <button type="button" class="btn" wire:click="moveListItemDown({{ $listIndex }}, {{ $itemIndex }})" @if($itemIndex === count($list['items']) - 1) disabled @endif>↓</button>
-                        <button type="button" class="btn btn-delete btn-sm" wire:click="removeListItem({{ $listIndex }}, {{ $itemIndex }})">Remove Item</button>
+                        <button type="button" class="btn" id="{{ $itemIndex }}" wire:click="moveListItemUp({{ $listIndex }}, $event.target.id)" @if($itemIndex === 0) disabled @endif>↑</button>
+                        <button type="button" class="btn" id="{{ $itemIndex }}" wire:click="moveListItemDown({{ $listIndex }}, $event.target.id)" @if($itemIndex === count($list['items']) - 1) disabled @endif>↓</button>
+                        <button type="button" class="btn btn-delete btn-sm" id="{{ $itemIndex }}" wire:click="removeListItem({{ $listIndex }}, $event.target.id)">Remove Item</button>
                     </div>
                 </div>
             @endforeach
 
             <div class="flex justify-start gap-3">
-                <button type="button" class="btn btn-delete" wire:click="removeList({{ $listIndex }})">Remove List</button>
-                <button type="button" class="btn" wire:click="addListItem({{ $listIndex }})">Add Item</button>
+                <button type="button" class="btn btn-delete" id="{{ $listIndex }}" wire:click="removeList($event.target.id)">Remove List</button>
+                <button type="button" class="btn" id="{{ $listIndex }}" wire:click="addListItem($event.target.id)">Add Item</button>
             </div>
 
             <div class="flex gap-2 mt-2">
-                <button type="button" class="btn" wire:click="moveListUp({{ $listIndex }})" @if($listIndex === 0) disabled @endif>↑ Move List Up</button>
-                <button type="button" class="btn" wire:click="moveListDown({{ $listIndex }})" @if($listIndex === count($lists) - 1) disabled @endif>↓ Move List Down</button>
+                <button type="button" class="btn" id="{{ $listIndex }}" wire:click="moveListUp($event.target.id)" @if($listIndex === 0) disabled @endif>↑ Move List Up</button>
+                <button type="button" class="btn" id="{{ $listIndex }}" wire:click="moveListDown($event.target.id)" @if($listIndex === count($lists) - 1) disabled @endif>↓ Move List Down</button>
             </div>
         </div>
     @endforeach

--- a/resources/views/livewire/portfolio-edit.blade.php
+++ b/resources/views/livewire/portfolio-edit.blade.php
@@ -8,10 +8,10 @@
             <div class="border mt-3 p-3 rounded border-primary-dark dark:border-primary-light">
                 <span>{{ $portfolio->name }}</span>
                 <div class="grid md:grid-cols-2 gap-5 mt-2">
-                    <button wire:click="deletePortfolio({{ $portfolio->id }})" wire:confirm="{{ __('text.are-you-sure') }}" class="btn-delete" id="delete-redirect" data-id="{{ $portfolio->id }}">
+                    <button id="{{ $portfolio->id }}" wire:click="deletePortfolio($event.target.id)" wire:confirm="{{ __('text.are-you-sure') }}" class="btn-delete" data-id="{{ $portfolio->id }}">
                         <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}" alt="{{ __('alt.close') }}" title="{{ __('alt.close') }}" />
                     </button>
-                    <button wire:click="editPortfolio({{ $portfolio->id }})" id="{{ $portfolio->id }}" class="btn btn-edit">
+                    <button id="{{ $portfolio->id }}" wire:click="editPortfolio($event.target.id)" class="btn btn-edit">
                         <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/pencil-outline.svg') }}" alt="{{ __('alt.edit') }}" title="{{ __('alt.edit') }}" />
                     </button>
                 </div>

--- a/resources/views/livewire/redirects.blade.php
+++ b/resources/views/livewire/redirects.blade.php
@@ -73,10 +73,10 @@
                         </div>
                     </div>
                     <div class="grid grid-cols-3 gap-5 mt-2">
-                        <button wire:click="deleteRedirect({{ $redirect->id }})" wire:confirm="{{ __('text.are-you-sure') }}" class="btn btn-delete" id="delete-redirect" data-id="{{ $redirect->id }}">
+                        <button id="{{ $redirect->id }}" wire:click="deleteRedirect($event.target.id)" wire:confirm="{{ __('text.are-you-sure') }}" class="btn btn-delete" data-id="{{ $redirect->id }}">
                             <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}"  alt="{{ __('alt.close') }}" title="{{ __('alt.close') }}"/>
                         </button>
-                        <button wire:click="editRedirect({{ $redirect->id }})" id="e-{{ $redirect->id }}" class="btn btn-edit">
+                        <button id="{{ $redirect->id }}" wire:click="editRedirect($event.target.id)" class="btn btn-edit">
                             <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/pencil-outline.svg') }}"  alt="{{ __('alt.edit') }}" title="{{ __('alt.edit') }}"/>
                         </button>
                         <button data-copy="true" data-text="{{ $redirect->url }}" class="btn btn-diff">

--- a/resources/views/livewire/rss-feeds.blade.php
+++ b/resources/views/livewire/rss-feeds.blade.php
@@ -27,7 +27,7 @@
                 <button id="{{ $feed->id }}" wire:click="deleteFeed($event.target.id)" class="btn btn-delete" type="button" wire:confirm="{{ __('text.are-you-sure') }}">
                     <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/close.svg') }}" alt="{{ __('alt.close') }}" title="{{ __('alt.close') }}"/>
                 </button>
-                <button wire:click="editFeed({{ $feed->id }})" class="btn btn-edit">
+                <button id="{{ $feed->id }}" wire:click="editFeed($event.target.id)" class="btn btn-edit">
                     <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/pencil-outline.svg') }}" alt="{{ __('alt.edit') }}" title="{{ __('alt.edit') }}"/>
                 </button>
             </div>

--- a/resources/views/livewire/testobject.blade.php
+++ b/resources/views/livewire/testobject.blade.php
@@ -55,7 +55,7 @@
             <p><strong>{{ __('text.deleted') }}:</strong> {{ $testrun->deletedWhen()}}</p>
 
             <div class="grid grid-cols-3 sm:grid-cols-5 gap-3 align-middle">
-                <button class="btn btn-delete" wire:click="deleteRun({{$testrun->id}})" wire:confirm="Are you sure?">
+                <button class="btn btn-delete" id="{{ $testrun->id }}" wire:click="deleteRun($event.target.id)" wire:confirm="Are you sure?">
                     <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}"  alt="{{ __('alt.delete') }}" title="{{ __('alt.delete') }}"/>
                 </button>
                 <a alt="{{ __('alt.view') }}" title="{{ __('alt.view') }}" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testrun/{$testrun->id}")}}" >

--- a/resources/views/livewire/testobjects.blade.php
+++ b/resources/views/livewire/testobjects.blade.php
@@ -70,10 +70,10 @@
             <p><strong>URL:</strong> {{ $testObj->url }}</p>
 
             <div class="grid grid-cols-3 sm:grid-cols-5 gap-3 align-middle">
-                <button class="btn btn-delete" wire:click="deleteObject({{ $testObj->id }})" wire:confirm="Are you sure?">
+                <button class="btn btn-delete" id="{{ $testObj->id }}" wire:click="deleteObject($event.target.id)" wire:confirm="Are you sure?">
                     <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}"  alt="{{ __('alt.delete') }}" title="{{ __('alt.delete') }}"/>
                 </button>
-                <button class="btn btn-edit" wire:click="editObject({{ $testObj->id }})">
+                <button class="btn btn-edit" id="{{ $testObj->id }}" wire:click="editObject($event.target.id)">
                     <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt="{{ __('alt.sync') }}" title="{{ __('alt.sync') }}"/>
                 </button>
                 <a alt="{{ __('alt.view') }}" title="{{ __('alt.view') }}" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testobject/{$testObj->id}")}}">

--- a/resources/views/livewire/testrun.blade.php
+++ b/resources/views/livewire/testrun.blade.php
@@ -74,20 +74,20 @@
             <p><strong>Status:</strong> {{ empty($testinstance->html) ? __('text.empty') : __('text.filled')}}</p>
 
             <div class="grid grid-cols-3 sm:grid-cols-5 gap-3 align-middle">
-                <button class="btn btn-delete" wire:click="deleteInstance({{$testinstance->id}})" wire:confirm="Are you sure?">
+                <button class="btn btn-delete" id="{{ $testinstance->id }}" wire:click="deleteInstance($event.target.id)" wire:confirm="Are you sure?">
                     <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}" alt="{{ __('alt.delete') }}" title="{{ __('alt.delete') }}" />
                 </button>
                 <a alt="{{ __('alt.view') }}" title="{{ __('alt.view') }}" class="btn btn-details" wire:navigate.hover href="{{url(Config::get('app.locale') . "/tester/testinstance/{$testinstance->id}")}}" >
                     <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/eye.svg') }}" alt="{{ __('alt.view') }}" title="{{ __('alt.view') }}" />
                 </a>
-                <button class="btn btn-fetch" wire:navigate wire:click="fetchInstance({{$testinstance->id}})"")}}" >
+                <button class="btn btn-fetch" wire:navigate id="{{ $testinstance->id }}" wire:click="fetchInstance($event.target.id)">
                     <img
                         class="w-20 h-5 invert"
                         src="{{ Vite::asset('resources/icons/' . (empty($testinstance->html) ? 'download.svg' : 'arrow-down.svg')) }}"
                         alt="{{ __('alt.download') }}" title="{{ __('alt.download') }}"
                     />
                 </button>
-                <button class="btn btn-diff" wire:click="addToDiff({{$testinstance->id}})">
+                <button class="btn btn-diff" id="{{ $testinstance->id }}" wire:click="addToDiff($event.target.id)">
                     <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/git-compare.svg') }}" alt="{{ __('alt.compare') }}" title="{{ __('alt.compare') }}" />
                 </button>
             </div>

--- a/resources/views/livewire/timetrack-edit-single.blade.php
+++ b/resources/views/livewire/timetrack-edit-single.blade.php
@@ -43,8 +43,8 @@
 
     </div>
     <button type="button"
-        class="btn btn-delete mb-3"
-        wire:click="removeTimeTrack({{ $i }})">✕</button>
+        class="btn btn-delete mb-3" id="{{ $i }}"
+        wire:click="removeTimeTrack($event.target.id)">✕</button>
     <hr class="w-full border-t border-gray-300 mb-3">
     @endforeach
 

--- a/resources/views/livewire/timetrack-edit.blade.php
+++ b/resources/views/livewire/timetrack-edit.blade.php
@@ -13,7 +13,7 @@
             <button data-copy="true" data-text="{{url(Config::get('app.locale') . '/' . __('url.timetracking') . '/' . $timetrack->id)}}" class="justify-center w-full p-2 py-2.5 px-4 bg-blue-500 text-white rounded hover:bg-blue-700 flex items-center edit-redirect">
                 <img class="w-10 h-5 invert" src="{{ Vite::asset('resources/icons/link-outline.svg') }}"  alt="{{ __('alt.link') }}" title="{{ __('alt.link') }}"/>
             </button>
-            <button class="btn btn-delete" wire:click="deleteTimetrack({{$timetrack->id}})" wire:confirm="Are you sure?">
+            <button class="btn btn-delete" id="{{ $timetrack->id }}" wire:click="deleteTimetrack($event.target.id)" wire:confirm="Are you sure?">
                 <img class="w-20 h-5 invert" src="{{ Vite::asset('resources/icons/trash.svg') }}"  alt="{{ __('alt.delete') }}" title="{{ __('alt.delete') }}"/>
             </button>
         </div>


### PR DESCRIPTION
## Summary
- pass IDs via `id` attributes and use `$event.target.id` in Livewire actions

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68403dfafec483208d789fc2c75ab0c6