### PR TITLE
Fix clipboard listeners for Livewire updates

### DIFF
--- a/resources/js/utils/clipboard.js
+++ b/resources/js/utils/clipboard.js
@@ -43,11 +43,13 @@ export function copyText(text) {
     document.body.removeChild(tempInput);
 }
 
+document.addEventListener('DOMContentLoaded', updateCopyEventListeners);
 document.addEventListener("livewire:navigated", updateCopyEventListeners);
-
-Livewire.hook("morphed", (componet) => {
-    updateCopyEventListeners();
-});
+if (window.Livewire) {
+    Livewire.hook("morphed", (componet) => {
+        updateCopyEventListeners();
+    });
+}
 
 function updateCopyEventListeners() {
     document.querySelectorAll('[data-copy="true"]').forEach(function (button) {


### PR DESCRIPTION
## Summary
- ensure clipboard event listeners initialize when DOM ready
- guard Livewire hooks to avoid `Livewire` undefined errors

## Testing
- `npm test` *(fails: Missing script)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68403eb715b88320908cb7ec2ec9b786