### PR TITLE
Add email layout and locale dispatch

### DIFF
--- a/app/Console/Commands/CheckRssFeeds.php
+++ b/app/Console/Commands/CheckRssFeeds.php
@@ -31,13 +31,15 @@ class CheckRssFeeds extends Command
 
                     $user = User::find($feed->user);
                     if ($user) {
-                        Mail::to($user->email)->queue(new RssFeedNotification([
+                        Mail::to($user->email)
+                            ->locale(app()->getLocale())
+                            ->queue(new RssFeedNotification([
                             'url' => $feed->url,
                             'title' => $latest,
                             'description' => (string)($item->description ?? ''),
                             'link' => (string)($item->link ?? ''),
                             'pubDate' => (string)($item->pubDate ?? ''),
-                        ]));
+                        ], app()->getLocale()));
                     }
                 }
             } catch (\Exception $e) {

--- a/app/Livewire/Account.php
+++ b/app/Livewire/Account.php
@@ -53,11 +53,13 @@ class Account extends Component
         $this->user->generatePermissionsToken();
         $this->user->save();
 
-        Mail::to("hp@diesing.pro")->queue(
+        Mail::to("hp@diesing.pro")
+            ->locale(app()->getLocale())
+            ->queue(
             new \App\Mail\RequestAccess([
                 "user" => $this->user,
                 "permission" => $permission,
-            ])
+            ], app()->getLocale())
         );
 
         session()->flash("status", __("text.access_request_sent"));

--- a/app/Livewire/ContactForm.php
+++ b/app/Livewire/ContactForm.php
@@ -37,6 +37,7 @@ class ContactForm extends Component
         $validatedData = $this->validate();
 
         Mail::to($this->recepient)
+            ->locale(app()->getLocale())
             ->bcc("info@diesing.pro")
             ->queue(
                 new ContactEmail([
@@ -45,7 +46,7 @@ class ContactForm extends Component
                     "email" => $this->email,
                     "tel" => $this->tel,
                     "user_message" => $this->message,
-                ])
+                ], app()->getLocale())
             );
 
         $this->reset();

--- a/app/Mail/ContactEmail.php
+++ b/app/Mail/ContactEmail.php
@@ -15,7 +15,6 @@ class ContactEmail extends Mailable implements ShouldQueue, ShouldBeUnique
     use Queueable, SerializesModels;
 
     protected $data;
-    public string $locale;
 
     /**
      * Create a new message instance.

--- a/app/Mail/ContactEmail.php
+++ b/app/Mail/ContactEmail.php
@@ -15,13 +15,15 @@ class ContactEmail extends Mailable implements ShouldQueue, ShouldBeUnique
     use Queueable, SerializesModels;
 
     protected $data;
+    public string $locale;
 
     /**
      * Create a new message instance.
      */
-    public function __construct(array $data)
+    public function __construct(array $data, ?string $locale = null)
     {
         $this->data = $data;
+        $this->locale = $locale ?? app()->getLocale();
 
         $this->replyTo(
             $data["email"] ?? "info@diesing.pro",
@@ -50,6 +52,7 @@ class ContactEmail extends Mailable implements ShouldQueue, ShouldBeUnique
                 "email" => $this->data["email"],
                 "tel" => $this->data["tel"],
                 "user_msg" => $this->data["user_message"],
+                "locale" => $this->locale,
             ]
         );
     }

--- a/app/Mail/RequestAccess.php
+++ b/app/Mail/RequestAccess.php
@@ -15,7 +15,6 @@ class RequestAccess extends Mailable implements ShouldQueue, ShouldBeUnique
     use Queueable, SerializesModels;
 
     protected $data;
-    public string $locale;
 
     /**
      * Create a new message instance.

--- a/app/Mail/RequestAccess.php
+++ b/app/Mail/RequestAccess.php
@@ -15,13 +15,15 @@ class RequestAccess extends Mailable implements ShouldQueue, ShouldBeUnique
     use Queueable, SerializesModels;
 
     protected $data;
+    public string $locale;
 
     /**
      * Create a new message instance.
      */
-    public function __construct(array $data)
+    public function __construct(array $data, ?string $locale = null)
     {
         $this->data = $data;
+        $this->locale = $locale ?? app()->getLocale();
     }
 
     /**
@@ -42,6 +44,7 @@ class RequestAccess extends Mailable implements ShouldQueue, ShouldBeUnique
             with: [
                 "user" => $this->data["user"],
                 "permission" => $this->data["permission"],
+                "locale" => $this->locale,
             ]
         );
     }

--- a/app/Mail/RssFeedNotification.php
+++ b/app/Mail/RssFeedNotification.php
@@ -15,10 +15,12 @@ class RssFeedNotification extends Mailable implements ShouldQueue, ShouldBeUniqu
     use Queueable, SerializesModels;
 
     protected $data;
+    public string $locale;
 
-    public function __construct(array $data)
+    public function __construct(array $data, ?string $locale = null)
     {
         $this->data = $data;
+        $this->locale = $locale ?? app()->getLocale();
     }
 
     public function envelope(): Envelope
@@ -36,6 +38,7 @@ class RssFeedNotification extends Mailable implements ShouldQueue, ShouldBeUniqu
                 'description' => $this->data['description'] ?? '',
                 'link' => $this->data['link'] ?? '',
                 'pubDate' => $this->data['pubDate'] ?? '',
+                'locale' => $this->locale,
             ]
         );
     }

--- a/app/Mail/RssFeedNotification.php
+++ b/app/Mail/RssFeedNotification.php
@@ -15,7 +15,6 @@ class RssFeedNotification extends Mailable implements ShouldQueue, ShouldBeUniqu
     use Queueable, SerializesModels;
 
     protected $data;
-    public string $locale;
 
     public function __construct(array $data, ?string $locale = null)
     {

--- a/resources/views/accounts/email/request-access.blade.php
+++ b/resources/views/accounts/email/request-access.blade.php
@@ -1,31 +1,10 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport"
-          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+@extends('layouts.email')
 
-    <style>
-        p {
-            font-size: 12px;
-        }
-
-        .signature {
-            font-style: italic;
-        }
-    </style>
-</head>
-<body>
-<div>
+@section('content')
 <p>User: {{ $user->name }}</p>
 <p>Username: {{ $user->username }}</p>
 <p>Email: {{ $user->email }}</p>
 <p>Permission: {{ $permission }}</p>
 <p><a alt="{{ __('alt.grant_access') }}" title="{{ __('alt.grant_access') }}" href="{{ url('/grant/' . $user->username . '/' . $permission . '/' . $user->permissions_token) }}">Grant Access</a></p>
 <p><a alt="{{ __('alt.remove_access') }}" title="{{ __('alt.remove_access') }}" href="{{ url('/ungrant/' . $user->username . '/' . $permission . '/' . $user->permissions_token) }}">Remove Access</a></p>
-
-
-</div>
-</body>
-</html>
+@endsection

--- a/resources/views/contact/email.blade.php
+++ b/resources/views/contact/email.blade.php
@@ -1,30 +1,10 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport"
-          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+@extends('layouts.email')
 
-    <style>
-        p {
-            font-size: 12px;
-        }
-
-        .signature {
-            font-style: italic;
-        }
-    </style>
-</head>
-<body>
-<div>
+@section('content')
 <p>Message from: {{ $name }} ({{ $email }})</p>
 <p>Company: {{ $firma }}</p>
 <p>Tel: {{ $tel }}</p>
 <p>E-Mail: {{ $email }}</p>
 
 <p>{{ $user_msg }}</p>
-
-</div>
-</body>
-</html>
+@endsection

--- a/resources/views/layouts/email.blade.php
+++ b/resources/views/layouts/email.blade.php
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="{{ str_replace('_', '-', $locale ?? app()->getLocale()) }}">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body style="font-family: Arial, sans-serif;">
+    <header style="text-align: center; margin-bottom: 20px;">
+        @include('global.logo')
+    </header>
+
+    <main>
+        @yield('content')
+    </main>
+
+    <footer style="text-align: center; margin-top: 20px; font-size: 12px;">
+        <a href="{{ url(($locale ?? app()->getLocale()) . '/' . __('url.imprint')) }}" style="margin-right: 10px;">
+            {{ __('text.imprint') }}
+        </a>
+        <a href="{{ url(($locale ?? app()->getLocale()) . '/' . __('url.data-protection')) }}">
+            {{ __('text.data-protection') }}
+        </a>
+    </footer>
+</body>
+</html>

--- a/resources/views/layouts/email.blade.php
+++ b/resources/views/layouts/email.blade.php
@@ -4,9 +4,11 @@
     <meta charset="UTF-8">
 </head>
 <body style="font-family: Arial, sans-serif;">
-    <header style="text-align: center; margin-bottom: 20px;">
-        @include('global.logo')
-    </header>
+        <header style="text-align: center; margin-bottom: 20px;">
+            <div style="display: inline-block; width: 120px;"> <!-- Adjust width as needed -->
+                @include('global.logo')
+            </div>
+        </header>
 
     <main>
         @yield('content')

--- a/resources/views/rss/email/new-item.blade.php
+++ b/resources/views/rss/email/new-item.blade.php
@@ -1,10 +1,6 @@
-<!doctype html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-</head>
-<body>
+@extends('layouts.email')
+
+@section('content')
 <p>New item in feed {{ $url }}</p>
 <p><a href="{{ $link }}">{{ $title }}</a></p>
 @if(!empty($description))
@@ -13,5 +9,4 @@
 @if(!empty($pubDate))
 <p><small>{{ $pubDate }}</small></p>
 @endif
-</body>
-</html>
+@endsection


### PR DESCRIPTION
## Summary
- design new `layouts.email` template with logo and links
- update mail templates to use the new layout
- include locale in all mailables and when sending mail

## Testing
- `composer test` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68405bc6de94832080542930c3cdcec3