### PR TITLE
Add confirmation email on contact form submission

### DIFF
--- a/app/Livewire/ContactForm.php
+++ b/app/Livewire/ContactForm.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use App\Mail\ContactEmail;
+use App\Mail\ContactConfirmationEmail;
 use App\Models\User;
 use Livewire\Component;
 use Illuminate\Support\Facades\Mail;
@@ -47,6 +48,12 @@ class ContactForm extends Component
                     "tel" => $this->tel,
                     "user_message" => $this->message,
                 ], app()->getLocale())
+            );
+
+        Mail::to($this->email)
+            ->locale(app()->getLocale())
+            ->queue(
+                new ContactConfirmationEmail($this->name, app()->getLocale())
             );
 
         $this->reset();

--- a/app/Mail/ContactConfirmationEmail.php
+++ b/app/Mail/ContactConfirmationEmail.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ContactConfirmationEmail extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    protected $name;
+    protected $locale;
+
+    public function __construct(string $name, ?string $locale = null)
+    {
+        $this->name = $name;
+        $this->locale = $locale ?? app()->getLocale();
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(subject: __("text.contact-confirmation-subject", [], $this->locale));
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'contact.confirmation',
+            with: [
+                'name' => $this->name,
+                'locale' => $this->locale,
+            ]
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/lang/de/text.php
+++ b/lang/de/text.php
@@ -5,6 +5,8 @@ return [
     'contact' => 'Kontakt',
     'contact-description' => 'Wenn Sie Fragen haben oder Unterstützung benötigen, können Sie uns gerne kontaktieren.',
     'message-sent' => 'Ihre Nachricht wurde erfolgreich gesendet!',
+    'contact-confirmation-subject' => 'Vielen Dank für Ihre Anfrage',
+    'contact-confirmation-body' => 'Vielen Dank für Ihre Kontaktaufnahme. Wir werden so schnell wie möglich antworten.',
     'select-recepient' => 'Empfänger auswählen',
     'portfolio' => 'Portfolio',
     'portfolio-description' => 'Hier finden Sie eine Auswahl unserer Projekte.',

--- a/lang/en/text.php
+++ b/lang/en/text.php
@@ -5,6 +5,8 @@ return [
     'contact' => 'Contact',
     'contact-description' => 'If you have any questions or need help, feel free to contact us.',
     'message-sent' => 'Your message has been sent successfully!',
+    'contact-confirmation-subject' => 'Thank you for your request',
+    'contact-confirmation-body' => 'Thank you for reaching out. We will reply as soon as possible.',
     'select-recepient' => 'Select a Recepient',
     'portfolio' => 'Portfolio',
     'portfolio-description' => 'Here you can find a selection of our projects.',

--- a/resources/views/contact/confirmation.blade.php
+++ b/resources/views/contact/confirmation.blade.php
@@ -1,0 +1,5 @@
+@extends('layouts.email')
+
+@section('content')
+<p>{{ __('text.contact-confirmation-body') }}</p>
+@endsection


### PR DESCRIPTION
## Summary
- send confirmation email when a visitor submits contact form
- localize confirmation subject and message in English and German
- add confirmation mail view and mailable

## Testing
- `npm --version`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68405f54bd9883208596473da6fb0cb0