### PR TITLE
Add sender name to contact email subject

### DIFF
--- a/app/Mail/ContactEmail.php
+++ b/app/Mail/ContactEmail.php
@@ -35,7 +35,12 @@ class ContactEmail extends Mailable implements ShouldQueue, ShouldBeUnique
      */
     public function envelope(): Envelope
     {
-        return new Envelope(subject: "Kontaktanfrage");
+        $subject = 'Kontaktanfrage';
+        if (!empty($this->data['name'])) {
+            $subject .= ' (' . $this->data['name'] . ')';
+        }
+
+        return new Envelope(subject: $subject);
     }
 
     /**


### PR DESCRIPTION
## Summary
- show sender's name in admin contact email subject

## Testing
- `./vendor/bin/phpunit tests/Unit/TrueTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68406185f94883209ebf76064a8d3405