### PR TITLE
Add loading state to contact form submit button

### DIFF
--- a/resources/views/livewire/contact-form.blade.php
+++ b/resources/views/livewire/contact-form.blade.php
@@ -86,9 +86,10 @@
             @error('message')
                 <span class="text-red-500 text-sm block">{{ $message }}</span>
             @enderror
-            <button type="submit" id="contact-submit" tabindex="6" class="mt-2 p-4 btn flex items-center gap-2">
-                <img class="w-6 h-6 invert" src="{{ Vite::asset('resources/icons/envelope.svg') }}" alt="Send" title="Send" />
-                {{ __('text.submit') }}
+            <button type="submit" id="contact-submit" tabindex="6" class="mt-2 p-4 btn flex items-center gap-2" wire:loading.attr="disabled">
+                <img wire:loading.remove class="w-6 h-6 invert" src="{{ Vite::asset('resources/icons/envelope.svg') }}" alt="Send" title="Send" />
+                <span wire:loading.remove>{{ __('text.submit') }}</span>
+                <img wire:loading class="w-4 h-4 animate-spin invert" src="{{ Vite::asset('resources/icons/sync.svg') }}" alt="{{ __('alt.sync') }}" title="{{ __('alt.sync') }}" />
             </button>
         </div>
     </form>


### PR DESCRIPTION
## Summary
- disable the contact form submit button when Livewire is processing
- show a spinner while the form submission is loading

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_684084a8ca7c8320b8440344d3132f23