### PR TITLE
Refactor email classes to remove data arrays

### DIFF
--- a/app/Console/Commands/CheckRssFeeds.php
+++ b/app/Console/Commands/CheckRssFeeds.php
@@ -33,13 +33,14 @@ class CheckRssFeeds extends Command
                     if ($user) {
                         Mail::to($user->email)
                             ->locale(app()->getLocale())
-                            ->queue(new RssFeedNotification([
-                            'url' => $feed->url,
-                            'title' => $latest,
-                            'description' => (string)($item->description ?? ''),
-                            'link' => (string)($item->link ?? ''),
-                            'pubDate' => (string)($item->pubDate ?? ''),
-                        ], app()->getLocale()));
+                            ->queue(new RssFeedNotification(
+                                $feed->url,
+                                $latest,
+                                (string)($item->description ?? ''),
+                                (string)($item->link ?? ''),
+                                (string)($item->pubDate ?? ''),
+                                app()->getLocale(),
+                            ));
                     }
                 }
             } catch (\Exception $e) {

--- a/app/Livewire/Account.php
+++ b/app/Livewire/Account.php
@@ -56,10 +56,11 @@ class Account extends Component
         Mail::to("hp@diesing.pro")
             ->locale(app()->getLocale())
             ->queue(
-            new \App\Mail\RequestAccess([
-                "user" => $this->user,
-                "permission" => $permission,
-            ], app()->getLocale())
+            new \App\Mail\RequestAccess(
+                $this->user,
+                $permission,
+                app()->getLocale(),
+            )
         );
 
         session()->flash("status", __("text.access_request_sent"));

--- a/app/Livewire/ContactForm.php
+++ b/app/Livewire/ContactForm.php
@@ -40,13 +40,14 @@ class ContactForm extends Component
         Mail::to($this->recepient)
             ->locale(app()->getLocale())
             ->queue(
-                new ContactEmail([
-                    "name" => $this->name,
-                    "firma" => $this->firma,
-                    "email" => $this->email,
-                    "tel" => $this->tel,
-                    "user_message" => $this->message,
-                ], app()->getLocale())
+                new ContactEmail(
+                    $this->name,
+                    $this->firma,
+                    $this->email,
+                    $this->tel,
+                    $this->message,
+                    app()->getLocale(),
+                )
             );
 
         Mail::to($this->email)

--- a/app/Mail/ContactConfirmationEmail.php
+++ b/app/Mail/ContactConfirmationEmail.php
@@ -21,10 +21,7 @@ class ContactConfirmationEmail extends Mailable implements ShouldQueue, ShouldBe
         $this->name = $name;
         $this->locale = $locale ?? app()->getLocale();
 
-        $this->replyTo(
-            $data["email"] ?? "info@diesing.pro",
-            $data["name"] ?? "Diesing.pro"
-        );
+        $this->replyTo('info@diesing.pro', 'Diesing.pro');
     }
 
     public function envelope(): Envelope

--- a/app/Mail/ContactEmail.php
+++ b/app/Mail/ContactEmail.php
@@ -14,19 +14,33 @@ class ContactEmail extends Mailable implements ShouldQueue, ShouldBeUnique
 {
     use Queueable, SerializesModels;
 
-    protected $data;
+    protected string $name;
+    protected ?string $firma;
+    protected string $email;
+    protected string $tel;
+    protected string $userMessage;
 
     /**
      * Create a new message instance.
      */
-    public function __construct(array $data, ?string $locale = null)
-    {
-        $this->data = $data;
+    public function __construct(
+        string $name,
+        ?string $firma,
+        string $email,
+        string $tel,
+        string $userMessage,
+        ?string $locale = null
+    ) {
+        $this->name = $name;
+        $this->firma = $firma;
+        $this->email = $email;
+        $this->tel = $tel;
+        $this->userMessage = $userMessage;
         $this->locale = $locale ?? app()->getLocale();
 
         $this->replyTo(
-            $data["email"] ?? "info@diesing.pro",
-            $data["name"] ?? "Diesing.pro"
+            $this->email ?? 'info@diesing.pro',
+            $this->name ?? 'Diesing.pro'
         );
     }
 
@@ -36,8 +50,8 @@ class ContactEmail extends Mailable implements ShouldQueue, ShouldBeUnique
     public function envelope(): Envelope
     {
         $subject = 'Kontaktanfrage';
-        if (!empty($this->data['name'])) {
-            $subject .= ' (' . $this->data['name'] . ')';
+        if (!empty($this->name)) {
+            $subject .= ' (' . $this->name . ')';
         }
 
         return new Envelope(subject: $subject);
@@ -49,14 +63,14 @@ class ContactEmail extends Mailable implements ShouldQueue, ShouldBeUnique
     public function content(): Content
     {
         return new Content(
-            view: "contact.email",
+            view: 'contact.email',
             with: [
-                "name" => $this->data["name"],
-                "firma" => $this->data["firma"],
-                "email" => $this->data["email"],
-                "tel" => $this->data["tel"],
-                "user_msg" => $this->data["user_message"],
-                "locale" => $this->locale,
+                'name' => $this->name,
+                'firma' => $this->firma,
+                'email' => $this->email,
+                'tel' => $this->tel,
+                'user_msg' => $this->userMessage,
+                'locale' => $this->locale,
             ]
         );
     }
@@ -72,11 +86,17 @@ class ContactEmail extends Mailable implements ShouldQueue, ShouldBeUnique
     }
 
     /**
-     * Generate a unique identifier hash based on the $data array.
+     * Generate a unique identifier hash based on the message data.
      */
     public function uniqueId(): string
     {
-        return md5(serialize($this->data));
+        return md5(serialize([
+            $this->name,
+            $this->firma,
+            $this->email,
+            $this->tel,
+            $this->userMessage,
+        ]));
     }
 
     /**

--- a/app/Mail/RequestAccess.php
+++ b/app/Mail/RequestAccess.php
@@ -2,6 +2,7 @@
 
 namespace App\Mail;
 
+use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -14,14 +15,16 @@ class RequestAccess extends Mailable implements ShouldQueue, ShouldBeUnique
 {
     use Queueable, SerializesModels;
 
-    protected $data;
+    protected User $user;
+    protected string $permission;
 
     /**
      * Create a new message instance.
      */
-    public function __construct(array $data, ?string $locale = null)
+    public function __construct(User $user, string $permission, ?string $locale = null)
     {
-        $this->data = $data;
+        $this->user = $user;
+        $this->permission = $permission;
         $this->locale = $locale ?? app()->getLocale();
     }
 
@@ -39,11 +42,11 @@ class RequestAccess extends Mailable implements ShouldQueue, ShouldBeUnique
     public function content(): Content
     {
         return new Content(
-            view: "accounts.email.request-access",
+            view: 'accounts.email.request-access',
             with: [
-                "user" => $this->data["user"],
-                "permission" => $this->data["permission"],
-                "locale" => $this->locale,
+                'user' => $this->user,
+                'permission' => $this->permission,
+                'locale' => $this->locale,
             ]
         );
     }
@@ -59,11 +62,14 @@ class RequestAccess extends Mailable implements ShouldQueue, ShouldBeUnique
     }
 
     /**
-     * Generate a unique identifier hash based on the $data array.
+     * Generate a unique identifier hash based on the message data.
      */
     public function uniqueId(): string
     {
-        return md5(serialize($this->data));
+        return md5(serialize([
+            $this->user->id,
+            $this->permission,
+        ]));
     }
 
     /**

--- a/app/Mail/RssFeedNotification.php
+++ b/app/Mail/RssFeedNotification.php
@@ -14,11 +14,25 @@ class RssFeedNotification extends Mailable implements ShouldQueue, ShouldBeUniqu
 {
     use Queueable, SerializesModels;
 
-    protected $data;
+    protected string $url;
+    protected string $title;
+    protected ?string $description;
+    protected ?string $link;
+    protected ?string $pubDate;
 
-    public function __construct(array $data, ?string $locale = null)
-    {
-        $this->data = $data;
+    public function __construct(
+        string $url,
+        string $title,
+        ?string $description = '',
+        ?string $link = '',
+        ?string $pubDate = '',
+        ?string $locale = null
+    ) {
+        $this->url = $url;
+        $this->title = $title;
+        $this->description = $description;
+        $this->link = $link;
+        $this->pubDate = $pubDate;
         $this->locale = $locale ?? app()->getLocale();
     }
 
@@ -32,11 +46,11 @@ class RssFeedNotification extends Mailable implements ShouldQueue, ShouldBeUniqu
         return new Content(
             view: 'rss.email.new-item',
             with: [
-                'url' => $this->data['url'],
-                'title' => $this->data['title'],
-                'description' => $this->data['description'] ?? '',
-                'link' => $this->data['link'] ?? '',
-                'pubDate' => $this->data['pubDate'] ?? '',
+                'url' => $this->url,
+                'title' => $this->title,
+                'description' => $this->description ?? '',
+                'link' => $this->link ?? '',
+                'pubDate' => $this->pubDate ?? '',
                 'locale' => $this->locale,
             ]
         );
@@ -49,7 +63,13 @@ class RssFeedNotification extends Mailable implements ShouldQueue, ShouldBeUniqu
 
     public function uniqueId(): string
     {
-        return md5(serialize($this->data));
+        return md5(serialize([
+            $this->url,
+            $this->title,
+            $this->description,
+            $this->link,
+            $this->pubDate,
+        ]));
     }
 
     public function uniqueFor(): int


### PR DESCRIPTION
## Summary
- avoid using `$data` arrays in mail classes
- store individual fields as typed properties
- update constructors and uniqueId logic
- adapt calling code to new constructors
- fix `ContactConfirmationEmail` to always set a valid reply-to address

## Testing
- `phpunit` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_b_68418ac716f88320a6fb4fa7c4cc6dae