### PR TITLE
Add dedicated email queue worker

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -93,4 +93,4 @@ jobs:
         username: root
         key: ${{ secrets.SSH_PRIVATE_KEY }}
         script: |
-          supervisorctl restart laravel-worker:*
+          supervisorctl restart laravel-worker:* laravel-email-worker:*

--- a/app/Jobs/SendEmail.php
+++ b/app/Jobs/SendEmail.php
@@ -15,6 +15,13 @@ class SendEmail implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /**
+     * All email jobs should be pushed to the dedicated queue.
+     *
+     * @var string
+     */
+    public string $queue = 'email';
+
     public $mailable;
     public $from;
     public $recipient;

--- a/laravel-worker.conf
+++ b/laravel-worker.conf
@@ -8,3 +8,14 @@ numprocs=4
 redirect_stderr=true
 stdout_logfile=/var/www/vhosts/diesing.pro/storage/logs/laravel-worker.log
 stopwaitsecs=3600
+
+[program:laravel-email-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=php /var/www/vhosts/diesing.pro/artisan queue:work --queue=email --sleep=3 --tries=2
+autostart=true
+autorestart=true
+user=www-data
+numprocs=2
+redirect_stderr=true
+stdout_logfile=/var/www/vhosts/diesing.pro/storage/logs/laravel-email-worker.log
+stopwaitsecs=3600


### PR DESCRIPTION
## Summary
- route email jobs to a dedicated queue
- configure supervisor to run a new `laravel-email-worker`
- restart email worker in deploy workflow

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68423af63858832082a0847247598a0b