### PR TITLE
Persist Random Teams data

### DIFF
--- a/app/Livewire/RandomTeams.php
+++ b/app/Livewire/RandomTeams.php
@@ -3,6 +3,8 @@
 namespace App\Livewire;
 
 use Livewire\Component;
+use Illuminate\Support\Facades\Auth;
+use App\Models\TeamsState;
 
 class RandomTeams extends Component
 {
@@ -13,6 +15,44 @@ class RandomTeams extends Component
     public $teamsLocked = false;
     public $games = [];
 
+    private function getState(): array
+    {
+        return [
+            'players' => $this->players,
+            'teams' => $this->teams,
+            'numberOfTeams' => $this->numberOfTeams,
+            'teamsLocked' => $this->teamsLocked,
+            'games' => $this->games,
+        ];
+    }
+
+    private function persistState(): void
+    {
+        if (Auth::check()) {
+            TeamsState::updateOrCreate(
+                ['user' => Auth::id()],
+                [
+                    'players' => $this->players,
+                    'teams' => $this->teams,
+                    'number_of_teams' => $this->numberOfTeams,
+                    'teams_locked' => $this->teamsLocked,
+                    'games' => $this->games,
+                ]
+            );
+        } else {
+            $this->dispatchBrowserEvent('random-teams-save', $this->getState());
+        }
+    }
+
+    public function loadState($data): void
+    {
+        $this->players = $data['players'] ?? [];
+        $this->teams = $data['teams'] ?? [];
+        $this->numberOfTeams = $data['numberOfTeams'] ?? 2;
+        $this->teamsLocked = $data['teamsLocked'] ?? false;
+        $this->games = $data['games'] ?? [];
+    }
+
     public function newPlayer()
     {
         if ($this->teamsLocked) {
@@ -20,6 +60,7 @@ class RandomTeams extends Component
         }
 
         $this->players[] = "";
+        $this->persistState();
     }
 
     public function updatePlayerName($name, $key)
@@ -32,6 +73,7 @@ class RandomTeams extends Component
         $this->players[$key] = $name;
 
         session(["teams-players" => $this->players]);
+        $this->persistState();
     }
 
     public function deletePlayer($key)
@@ -50,6 +92,7 @@ class RandomTeams extends Component
 
         session(["teams-players" => $this->players]);
         session(["teams-teams" => $this->teams]);
+        $this->persistState();
     }
 
     public function updateNumberOfTeams($number)
@@ -60,6 +103,7 @@ class RandomTeams extends Component
 
         $this->numberOfTeams = $number;
         session(["teams-number-of-teams" => $this->numberOfTeams]);
+        $this->persistState();
     }
 
     public function generateTeams()
@@ -91,6 +135,7 @@ class RandomTeams extends Component
         shuffle($this->teams);
 
         session(["teams-teams" => $this->teams]);
+        $this->persistState();
     }
 
     public function updateTeamName($name, $index)
@@ -106,6 +151,7 @@ class RandomTeams extends Component
 
         $this->teams[$index]['name'] = $name;
         session(["teams-teams" => $this->teams]);
+        $this->persistState();
     }
 
     public function lockTeams()
@@ -129,12 +175,14 @@ class RandomTeams extends Component
             'teams-games' => $this->games,
             'teams-locked' => $this->teamsLocked,
         ]);
+        $this->persistState();
     }
 
     public function unlockTeams()
     {
         $this->teamsLocked = false;
         session(['teams-locked' => $this->teamsLocked]);
+        $this->persistState();
     }
 
     public function updateWins($index, $delta)
@@ -155,15 +203,29 @@ class RandomTeams extends Component
         $this->games[$gameIndex]['teams'][$index]['wins'] = $wins;
 
         session(['teams-games' => $this->games]);
+        $this->persistState();
     }
 
     public function mount()
     {
-        $this->players = session("teams-players", []);
-        $this->teams = session("teams-teams", []);
-        $this->numberOfTeams = session("teams-number-of-teams", 2);
-        $this->teamsLocked = session('teams-locked', false);
-        $this->games = session('teams-games', []);
+        if (Auth::check()) {
+            $state = TeamsState::firstOrCreate(
+                ['user' => Auth::id()],
+                ['players' => [], 'teams' => [], 'number_of_teams' => 2, 'teams_locked' => false, 'games' => []]
+            );
+            $this->players = $state->players ?? [];
+            $this->teams = $state->teams ?? [];
+            $this->numberOfTeams = $state->number_of_teams ?? 2;
+            $this->teamsLocked = $state->teams_locked ?? false;
+            $this->games = $state->games ?? [];
+        } else {
+            $this->players = session("teams-players", []);
+            $this->teams = session("teams-teams", []);
+            $this->numberOfTeams = session("teams-number-of-teams", 2);
+            $this->teamsLocked = session('teams-locked', false);
+            $this->games = session('teams-games', []);
+            $this->dispatchBrowserEvent('random-teams-request-state');
+        }
     }
 
     public function render()

--- a/app/Livewire/RandomTeams.php
+++ b/app/Livewire/RandomTeams.php
@@ -5,6 +5,7 @@ namespace App\Livewire;
 use Livewire\Component;
 use Illuminate\Support\Facades\Auth;
 use App\Models\TeamsState;
+use Livewire\Attributes\On;
 
 class RandomTeams extends Component
 {
@@ -40,10 +41,11 @@ class RandomTeams extends Component
                 ]
             );
         } else {
-            $this->dispatchBrowserEvent('random-teams-save', $this->getState());
+            $this->dispatch('random-teams-save', $this->getState());
         }
     }
 
+    #[On('loadState')]
     public function loadState($data): void
     {
         $this->players = $data['players'] ?? [];
@@ -224,7 +226,7 @@ class RandomTeams extends Component
             $this->numberOfTeams = session("teams-number-of-teams", 2);
             $this->teamsLocked = session('teams-locked', false);
             $this->games = session('teams-games', []);
-            $this->dispatchBrowserEvent('random-teams-request-state');
+            $this->dispatch('random-teams-request-state');
         }
     }
 

--- a/app/Models/TeamsState.php
+++ b/app/Models/TeamsState.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class TeamsState extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'teams_state';
+    protected $primaryKey = 'id';
+
+    protected $fillable = [
+        'user',
+        'players',
+        'teams',
+        'number_of_teams',
+        'teams_locked',
+        'games',
+    ];
+
+    protected $casts = [
+        'players' => 'array',
+        'teams' => 'array',
+        'games' => 'array',
+        'teams_locked' => 'boolean',
+        'number_of_teams' => 'integer',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,9 +6,11 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use App\Models\RssFeed;
+use App\Models\TeamsState;
 
 class User extends Authenticatable
 {
@@ -120,5 +122,10 @@ class User extends Authenticatable
     public function rssFeeds(): HasMany
     {
         return $this->hasMany(RssFeed::class, 'user', 'id');
+    }
+
+    public function teamsState()
+    {
+        return $this->hasOne(TeamsState::class, 'user', 'id');
     }
 }

--- a/database/migrations/2025_05_27_120000_create_teams_state.php
+++ b/database/migrations/2025_05_27_120000_create_teams_state.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('teams_state', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->timestamps();
+            $table->uuid('user')->nullable();
+            $table->json('players')->nullable();
+            $table->json('teams')->nullable();
+            $table->integer('number_of_teams')->default(2);
+            $table->boolean('teams_locked')->default(false);
+            $table->json('games')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('teams_state');
+    }
+};

--- a/resources/js/utils/random-teams-storage.js
+++ b/resources/js/utils/random-teams-storage.js
@@ -1,0 +1,33 @@
+const STORAGE_KEY = 'random_teams_state';
+
+function initRandomTeamsStorage() {
+    const body = document.querySelector('body');
+    if (!body || body.dataset.userLoggedIn === '1') {
+        return;
+    }
+
+    window.addEventListener('random-teams-save', (e) => {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(e.detail));
+        } catch (err) {
+            console.warn('Could not save random teams state', err);
+        }
+    });
+
+    window.addEventListener('random-teams-request-state', () => {
+        try {
+            const stored = localStorage.getItem(STORAGE_KEY);
+            if (stored) {
+                Livewire.dispatch('loadState', JSON.parse(stored));
+            }
+        } catch (err) {
+            console.warn('Could not load random teams state', err);
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', initRandomTeamsStorage);
+document.addEventListener('livewire:navigated', initRandomTeamsStorage);
+if (window.Livewire) {
+    Livewire.hook('morphed', initRandomTeamsStorage);
+}

--- a/resources/js/utils/random-teams-storage.js
+++ b/resources/js/utils/random-teams-storage.js
@@ -6,8 +6,11 @@ function initRandomTeamsStorage() {
         return;
     }
 
+    console.log('Initializing random teams storage');
+
     window.addEventListener('random-teams-save', (e) => {
         try {
+            console.log('Saving random teams state', e.detail);
             localStorage.setItem(STORAGE_KEY, JSON.stringify(e.detail));
         } catch (err) {
             console.warn('Could not save random teams state', err);
@@ -17,6 +20,7 @@ function initRandomTeamsStorage() {
     window.addEventListener('random-teams-request-state', () => {
         try {
             const stored = localStorage.getItem(STORAGE_KEY);
+            console.log('Requesting random teams state', stored);
             if (stored) {
                 Livewire.dispatch('loadState', JSON.parse(stored));
             }
@@ -28,6 +32,4 @@ function initRandomTeamsStorage() {
 
 document.addEventListener('DOMContentLoaded', initRandomTeamsStorage);
 document.addEventListener('livewire:navigated', initRandomTeamsStorage);
-if (window.Livewire) {
-    Livewire.hook('morphed', initRandomTeamsStorage);
-}
+initRandomTeamsStorage();

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -23,9 +23,10 @@
             'resources/js/scroll-to-top.js',
             'resources/js/logo-animation.js',
             'resources/js/utils/clipboard.js',
+            'resources/js/utils/random-teams-storage.js',
         ])
     </head>
-    <body class="bg-tertiary dark:bg-secondary-dark text-black dark:text-white">
+    <body class="bg-tertiary dark:bg-secondary-dark text-black dark:text-white" data-user-logged-in="{{ Auth::check() ? '1' : '0' }}">
         <div
             x-data="{ sidebarOpen: false }"
             @swiperight.window="sidebarOpen = true"

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
                 "resources/js/app.js",
                 "resources/js/gradient-scroll.js",
                 "resources/js/utils/clipboard.js",
+                "resources/js/utils/random-teams-storage.js",
                 "resources/js/utils/zenquotes.js",
                 "resources/js/utils/editor.js",
                 "resources/js/swipe-sidebar.js",


### PR DESCRIPTION
## Summary
- add migration and model for `TeamsState`
- persist random teams data to DB if user is logged in
- sync random teams data to `localStorage` when anonymous
- wire up new JS storage helper

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842498bfbd88320823b1ad0b6b62323