### PR TITLE
Add from parameters for account tool redirects

### DIFF
--- a/app/Http/Middleware/CvMiddleware.php
+++ b/app/Http/Middleware/CvMiddleware.php
@@ -33,7 +33,8 @@ class CvMiddleware
             "/" .
             __("url.account") .
             "?return_url=" .
-            urlencode($currentUrl);
+            urlencode($currentUrl) .
+            "&from=cv";
 
         return redirect($redirectUrl);
     }

--- a/app/Http/Middleware/NotesMiddleware.php
+++ b/app/Http/Middleware/NotesMiddleware.php
@@ -33,7 +33,8 @@ class NotesMiddleware
             "/" .
             __("url.account") .
             "?return_url=" .
-            urlencode($currentUrl);
+            urlencode($currentUrl) .
+            "&from=notes";
 
         return redirect($redirectUrl);
     }

--- a/app/Http/Middleware/PortfolioMiddleware.php
+++ b/app/Http/Middleware/PortfolioMiddleware.php
@@ -33,7 +33,8 @@ class PortfolioMiddleware
             "/" .
             __("url.account") .
             "?return_url=" .
-            urlencode($currentUrl);
+            urlencode($currentUrl) .
+            "&from=portfolio";
 
         return redirect($redirectUrl);
     }

--- a/app/Http/Middleware/RedirectsMiddleware.php
+++ b/app/Http/Middleware/RedirectsMiddleware.php
@@ -33,7 +33,8 @@ class RedirectsMiddleware
             "/" .
             __("url.account") .
             "?return_url=" .
-            urlencode($currentUrl);
+            urlencode($currentUrl) .
+            "&from=redirects";
 
         return redirect($redirectUrl);
     }

--- a/app/Http/Middleware/RssFeedsMiddleware.php
+++ b/app/Http/Middleware/RssFeedsMiddleware.php
@@ -22,7 +22,7 @@ class RssFeedsMiddleware
         }
 
         $currentUrl = URL::full();
-        $redirectUrl = Config::get('app.locale') . '/' . __('url.account') . '?return_url=' . urlencode($currentUrl);
+        $redirectUrl = Config::get('app.locale') . '/' . __('url.account') . '?return_url=' . urlencode($currentUrl) . '&from=rss-feeds';
         return redirect($redirectUrl);
     }
 }

--- a/app/Http/Middleware/TimetrackingMiddleware.php
+++ b/app/Http/Middleware/TimetrackingMiddleware.php
@@ -33,7 +33,8 @@ class TimetrackingMiddleware
             "/" .
             __("url.account") .
             "?return_url=" .
-            urlencode($currentUrl);
+            urlencode($currentUrl) .
+            "&from=timetracking";
 
         return redirect($redirectUrl);
     }

--- a/lang/de/text.php
+++ b/lang/de/text.php
@@ -211,6 +211,12 @@ return [
     'cv-contact-email-label' => 'E-Mail',
     'account-auth.tester' => '<p>Der Tester ist ein Tool, um Schnappschüsse von Websites zu erstellen und zu vergleichen.</p>'.
         '<p>Der Tester bietet auch eine HTML-Suche, einen Sitemap-Crawler und ein Bulk-Diff-Tool.</p>',
+    'account-auth.notes' => '<p>Mit den Notizen kannst du persönliche Notizen speichern.</p>',
+    'account-auth.redirects' => '<p>Weiterleitungen ermöglichen dir die Verwaltung von Kurzlinks zu anderen Websites.</p>',
+    'account-auth.portfolio' => '<p>Verwalte deine Projekte und Portfolioeinträge.</p>',
+    'account-auth.cv' => '<p>Bearbeite deinen persönlichen Lebenslauf.</p>',
+    'account-auth.timetracking' => '<p>Verfolge die auf Aufgaben und Projekte aufgewendete Zeit.</p>',
+    'account-auth.rss-feeds' => '<p>Verwalte personalisierte RSS-Feeds.</p>',
     'data-protection-page' => '
     <h1>Datenschutzerklärung</h1>
 

--- a/lang/en/text.php
+++ b/lang/en/text.php
@@ -210,6 +210,12 @@ return [
     'cv-contact-email-label' => 'Email',
     'account-auth.tester' => '<p>The Tester is a tool to create and compare snapshots of websites.</p>'.
         '<p>The tester also features a HTML search, a sitemap crawler, and a bulk diff tool.</p>',
+    'account-auth.notes' => '<p>The Notes tool lets you store personal notes.</p>',
+    'account-auth.redirects' => '<p>Redirects allow you to manage shortlinks to other websites.</p>',
+    'account-auth.portfolio' => '<p>Manage your projects and portfolio entries.</p>',
+    'account-auth.cv' => '<p>Edit your personal curriculum vitae.</p>',
+    'account-auth.timetracking' => '<p>Track the time spent on tasks and projects.</p>',
+    'account-auth.rss-feeds' => '<p>Manage personalized RSS feeds.</p>',
     'data-protection-page' => '
 <h1>Privacy Policy</h1>
 


### PR DESCRIPTION
## Summary
- append `from` query parameter to all account tool middlewares so login page can display context
- add translations for custom account-auth texts for each tool (de/en)

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68436bf4a57483208260c832d27ba1da