### PR TITLE
Implement automatic language detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains the source code for [diesing.pro](https://www.diesing.p
 
 Visit: <https://www.diesing.pro/>
 
-The site is available in English and German. It provides both public pages and a private account area for registered users.
+The site is available in English and German. It provides both public pages and a private account area for registered users. The displayed language is automatically selected based on the visitor's region when possible.
 
 ## Features
 

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -17,13 +17,28 @@ class SetLocale
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->segment(1) === "de") {
-            App::setLocale("de");
-            Carbon::setLocale('de');
-        } else {
-            App::setLocale("en");
-            Carbon::setLocale('en');
+        $locale = 'en';
+
+        $acceptLanguage = $request->server('HTTP_ACCEPT_LANGUAGE');
+        if ($acceptLanguage !== null) {
+            $browserLocales = explode(',', $acceptLanguage);
+            foreach ($browserLocales as $browserLocale) {
+                $langPrefix = substr($browserLocale, 0, 2);
+                if (in_array($langPrefix, ['de', 'en'])) {
+                    $locale = $langPrefix;
+                    break;
+                }
+            }
         }
+
+        if ($request->segment(1) === 'de') {
+            $locale = 'de';
+        } elseif ($request->segment(1) === 'en') {
+            $locale = 'en';
+        }
+
+        App::setLocale($locale);
+        Carbon::setLocale($locale);
 
         return $next($request);
     }


### PR DESCRIPTION
## Summary
- detect client language preference from headers
- update README to note automatic language detection

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68436c41c46c8320b6f374a15dc97f85