### PR TITLE
Add RSS feed names and include in notification subject

### DIFF
--- a/app/Console/Commands/CheckRssFeeds.php
+++ b/app/Console/Commands/CheckRssFeeds.php
@@ -40,6 +40,7 @@ class CheckRssFeeds extends Command
                                 (string)($item->link ?? ''),
                                 (string)($item->pubDate ?? ''),
                                 app()->getLocale(),
+                                $feed->name,
                             )
                         );
                     }

--- a/app/Livewire/RssFeeds.php
+++ b/app/Livewire/RssFeeds.php
@@ -11,6 +11,7 @@ class RssFeeds extends Component
     public $feeds;
     public $selectedFeed = [
         'id' => null,
+        'name' => '',
         'url' => '',
     ];
 
@@ -23,6 +24,7 @@ class RssFeeds extends Component
     {
         $feed = RssFeed::create([
             'url' => 'https://example.com/feed.xml',
+            'name' => 'New RSS Feed',
             'user' => Auth::user()->id,
         ]);
 
@@ -51,11 +53,15 @@ class RssFeeds extends Component
     {
         $this->validate([
             'selectedFeed.url' => 'required|url',
+            'selectedFeed.name' => 'required|string|max:255',
         ]);
 
         $feed = RssFeed::find($this->selectedFeed['id']);
         if ($feed) {
-            $feed->update(['url' => $this->selectedFeed['url']]);
+            $feed->update([
+                'url' => $this->selectedFeed['url'],
+                'name' => $this->selectedFeed['name'],
+            ]);
         }
         $this->cancelEdit();
         $this->mount();
@@ -63,7 +69,7 @@ class RssFeeds extends Component
 
     public function cancelEdit()
     {
-        $this->selectedFeed = ['id' => null, 'url' => ''];
+        $this->selectedFeed = ['id' => null, 'name' => '', 'url' => ''];
     }
 
     public function render()

--- a/app/Mail/RssFeedNotification.php
+++ b/app/Mail/RssFeedNotification.php
@@ -14,6 +14,7 @@ class RssFeedNotification extends Mailable
 
     protected string $url;
     protected string $title;
+    protected string $feedName;
     protected ?string $description;
     protected ?string $link;
     protected ?string $pubDate;
@@ -24,10 +25,12 @@ class RssFeedNotification extends Mailable
         ?string $description = '',
         ?string $link = '',
         ?string $pubDate = '',
-        ?string $locale = null
+        ?string $locale = null,
+        string $feedName = ''
     ) {
         $this->url = $url;
         $this->title = $title;
+        $this->feedName = $feedName;
         $this->description = $description;
         $this->link = $link;
         $this->pubDate = $pubDate;
@@ -36,7 +39,12 @@ class RssFeedNotification extends Mailable
 
     public function envelope(): Envelope
     {
-        return new Envelope(subject: 'New RSS Feed Item');
+        $subject = 'New RSS Feed Item';
+        if (!empty($this->feedName)) {
+            $subject .= ' - ' . $this->feedName;
+        }
+
+        return new Envelope(subject: $subject);
     }
 
     public function content(): Content

--- a/app/Models/RssFeed.php
+++ b/app/Models/RssFeed.php
@@ -13,8 +13,15 @@ class RssFeed extends Model
     protected $table = 'rss_feed';
     protected $primaryKey = 'id';
 
+    protected $attributes = [
+        'name' => 'New RSS Feed',
+        'url' => 'https://example.com/feed.xml',
+        'user' => 0,
+    ];
+
     protected $fillable = [
         'url',
+        'name',
         'user',
         'last_title',
         'last_checked_at',

--- a/database/migrations/2025_05_27_130001_rss_feed_add_name.php
+++ b/database/migrations/2025_05_27_130001_rss_feed_add_name.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rss_feed', function (Blueprint $table) {
+            if (!Schema::hasColumn('rss_feed', 'name')) {
+                $table->string('name')->default('')->after('url');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rss_feed', function (Blueprint $table) {
+            if (Schema::hasColumn('rss_feed', 'name')) {
+                $table->dropColumn('name');
+            }
+        });
+    }
+};

--- a/resources/views/livewire/rss-feeds.blade.php
+++ b/resources/views/livewire/rss-feeds.blade.php
@@ -7,7 +7,9 @@
         <div class="p-3 mt-5 rounded border-solid border w-full" style="border-color: #6b7280;">
             @if (isset($selectedFeed['id']) && $feed->id == $selectedFeed['id'])
             <form wire:submit.prevent="updateFeed">
-                <label for="edit-url" class="font-bold text-lg">URL</label>
+                <label for="edit-name" class="font-bold text-lg">{{ __('text.name') }}</label>
+                <input id="edit-name" type="text" wire:model="selectedFeed.name" class="w-full p-2 border rounded dark:bg-secondary-light" />
+                <label for="edit-url" class="font-bold text-lg mt-2">URL</label>
                 <input id="edit-url" type="text" wire:model="selectedFeed.url" class="w-full p-2 border rounded dark:bg-secondary-light" />
                 <div class="flex justify-end gap-3 mt-3">
                     <button type="button" wire:click="cancelEdit" class="btn btn-delete">
@@ -20,7 +22,10 @@
             </form>
             @else
             <div class="flex justify-between">
-                <span class="break-all">{{ $feed->url }}</span>
+                <div>
+                    <span class="font-bold">{{ $feed->name }}</span>
+                    <p class="break-all text-sm">{{ $feed->url }}</p>
+                </div>
                 <span class="text-sm text-gray-500">{{ $feed->updated_at->format('d.m.Y H:i') }}</span>
             </div>
             <div class="grid grid-cols-2 gap-5 mt-2">

--- a/tests/Unit/RssFeedNotificationTest.php
+++ b/tests/Unit/RssFeedNotificationTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Mail\RssFeedNotification;
+use Tests\TestCase;
+
+class RssFeedNotificationTest extends TestCase
+{
+    public function test_subject_includes_feed_name()
+    {
+        $mail = new RssFeedNotification('http://example.com', 'Title', '', '', '', 'en', 'My Feed');
+        $this->assertEquals('New RSS Feed Item - My Feed', $mail->envelope()->subject);
+    }
+}

--- a/tests/Unit/RssFeedTest.php
+++ b/tests/Unit/RssFeedTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\RssFeed;
+use Tests\TestCase;
+
+class RssFeedTest extends TestCase
+{
+    public function test_default_attributes()
+    {
+        $feed = new RssFeed();
+        $this->assertEquals('New RSS Feed', $feed->name);
+        $this->assertEquals('https://example.com/feed.xml', $feed->url);
+    }
+}


### PR DESCRIPTION
## Summary
- add `name` column to RSS feed table
- support feed names in model defaults and Livewire component
- show feed name in account UI
- include feed name in RSS notification email subject
- cover functionality with tests

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68436c67866c83208276521196047958