### PR TITLE
Optimize LCP image loading

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -8,7 +8,7 @@
     <div class="w-full rounded overflow-hidden shadow-lg mt-4 md:mt-0 home-card-left">
         <a alt="{{ __('text.contact') }}" title="{{ __('text.contact') }}" href="{{ url(Config::get('app.locale') . '/' . __('url.contact')) }}" wire:navigate.hover >
             <div class="relative h-0 pb-44">
-                <img class="absolute top-0 left-0 w-full h-44 object-cover" loading="eager"
+                <img class="absolute top-0 left-0 w-full h-44 object-cover" fetchpriority="high" loading="eager"
                     src="{{ Vite::asset('resources/images/kontakt.webp') }}" alt="{{ __('text.contact') }}" title="{{ __('text.contact') }}">
             </div>
             <div class="px-6 py-4 bg-primary-dark text-white dark:bg-primary">


### PR DESCRIPTION
## Summary
- add `fetchpriority="high"` to the contact hero image so it's prioritized in the HTML

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6849c7ab409483208675f57cce1b4e00