### PR TITLE
Implement menu alt text translations

### DIFF
--- a/resources/views/global/header.blade.php
+++ b/resources/views/global/header.blade.php
@@ -59,7 +59,13 @@ $contactOpen = in_array($activeTool ?? '', ['hp@diesing.pro', 'detlef.diesing@ic
                 aria-label="Toggle menu"
             >
                 <!-- Menu Icon -->
-                <img x-show="sidebarOpen" src="{{ Vite::asset('resources/icons/close.svg') }}" class="h-8 w-8 dark:invert" alt="Close Menu" title="Close Menu" />
+                <img
+                    x-show="sidebarOpen"
+                    src="{{ Vite::asset('resources/icons/close.svg') }}"
+                    class="h-8 w-8 dark:invert"
+                    alt="{{ __('alt.close_menu') }}"
+                    title="{{ __('alt.close_menu') }}"
+                />
             </button>
         </div>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -41,7 +41,13 @@
                 aria-label="Toggle menu"
             >
                 <!-- Menu Icon -->
-                <img x-show="!sidebarOpen" src="{{ Vite::asset('resources/icons/menu.svg') }}" class="h-10 w-10 burger-menu" alt="Open Menu" title="Open Menu" />
+                <img
+                    x-show="!sidebarOpen"
+                    src="{{ Vite::asset('resources/icons/menu.svg') }}"
+                    class="h-10 w-10 burger-menu"
+                    alt="{{ __('alt.open_menu') }}"
+                    title="{{ __('alt.open_menu') }}"
+                />
             </button>
 
             @include('global.header', ['active' => $active ?? null, 'activeTool' => $activeTool ?? null])


### PR DESCRIPTION
## Summary
- use `alt.open_menu` and `alt.close_menu` translations for menu buttons

## Testing
- `composer install` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68501123dc54832096a888b5fd5e798e