### PR TITLE
Add SEO keyword translations

### DIFF
--- a/lang/de/keywords.php
+++ b/lang/de/keywords.php
@@ -1,0 +1,16 @@
+<?php
+return [
+    "home" => "HP Diesing, Softwareentwickler, Webentwicklung, Portfolio, Echtzeit teilen, Zufallsteams, A-B-Tester",
+    "portfolio" => "Projektportfolio, Software, Webdesign, PHP, Laravel, JavaScript",
+    "contact" => "Kontakt, E-Mail, Nachricht, HP Diesing",
+    "random-teams" => "Zufallsteams, Team Generator, faire Teams, Gruppen Generator",
+    "account" => "Konto, Nutzertools, Notizen, Weiterleitungen",
+    "tester" => "A-B-Tester, Website Vergleich, Snapshot Tool",
+    "notes" => "Notizen, private Notizen, einfache Notizen",
+    "redirects" => "Weiterleitungen, benutzerdefinierte Weiterleitungen, URL Kurzlink",
+    "rt-share" => "Echtzeit teilen, P2P Dateiübertragung, Dateien senden, WebRTC",
+    "data-protection" => "Datenschutz, Datenschutzerklärung",
+    "imprint" => "Impressum, rechtliche Informationen, Kontaktinformation",
+    "cv" => "Lebenslauf, Curriculum Vitae, HP Diesing",
+    "rss-feeds" => "RSS Feeds, Updates, Benachrichtigungen, Abonnement",
+];

--- a/lang/en/keywords.php
+++ b/lang/en/keywords.php
@@ -1,0 +1,16 @@
+<?php
+return [
+    "home" => "HP Diesing, software developer, web development, portfolio, realtime share, random teams, A-B tester",
+    "portfolio" => "project portfolio, software, web design, PHP, Laravel, JavaScript",
+    "contact" => "contact, email, message, hp diesing",
+    "random-teams" => "random teams, team generator, fair teams, group generator",
+    "account" => "account, user tools, notes, redirects",
+    "tester" => "A-B tester, website comparison, snapshot tool",
+    "notes" => "notes, personal notes, simple notes",
+    "redirects" => "redirects, custom redirects, url shortener",
+    "rt-share" => "real-time share, p2p file transfer, send files, web rtc",
+    "data-protection" => "data protection, privacy policy",
+    "imprint" => "imprint, legal information, contact info",
+    "cv" => "cv, curriculum vitae, resume, hp diesing",
+    "rss-feeds" => "rss feeds, updates, subscription, notifications",
+];


### PR DESCRIPTION
## Summary
- add new translation files for SEO keywords in English and German

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6851813b4f54832097f92122e32bd6ab