### PR TITLE
Enhance auth form autocomplete

### DIFF
--- a/resources/views/livewire/account-auth.blade.php
+++ b/resources/views/livewire/account-auth.blade.php
@@ -3,7 +3,7 @@
     <form wire:submit.prevent="loginUser" class="mb-6">
         <h2 class="text-lg font-bold mb-2">{{ __('text.login') }}</h2>
         @include('global.partials.floating-label-input', [
-            'additional' => 'wire:model="login"',
+            'additional' => 'wire:model="login" autocomplete="username"',
             'id' => 'login',
             'name' => 'login',
             'label' => __('text.username_or_email'),
@@ -11,7 +11,7 @@
             'tabindex' => 1
         ])
         @include('global.partials.floating-label-input', [
-            'additional' => 'wire:model="loginPassword"',
+            'additional' => 'wire:model="loginPassword" autocomplete="current-password"',
             'id' => 'login-password',
             'name' => 'loginPassword',
             'label' => __('text.password'),
@@ -27,7 +27,7 @@
     <form wire:submit.prevent="register">
         <h2 class="text-lg font-bold mb-2">{{ __('text.register') }}</h2>
         @include('global.partials.floating-label-input', [
-            'additional' => 'wire:model="username"',
+            'additional' => 'wire:model="username" autocomplete="username"',
             'id' => 'username',
             'name' => 'username',
             'label' => __('text.username'),
@@ -35,7 +35,7 @@
             'tabindex' => 3
         ])
         @include('global.partials.floating-label-input', [
-            'additional' => 'wire:model="email"',
+            'additional' => 'wire:model="email" autocomplete="email"',
             'id' => 'email',
             'name' => 'email',
             'label' => __('text.email'),
@@ -43,7 +43,7 @@
             'tabindex' => 4
         ])
         @include('global.partials.floating-label-input', [
-            'additional' => 'wire:model="name"',
+            'additional' => 'wire:model="name" autocomplete="name"',
             'id' => 'name',
             'name' => 'name',
             'label' => __('text.name'),
@@ -51,7 +51,7 @@
             'tabindex' => 5
         ])
         @include('global.partials.floating-label-input', [
-            'additional' => 'wire:model="registerPassword"',
+            'additional' => 'wire:model="registerPassword" autocomplete="new-password"',
             'id' => 'register-password',
             'name' => 'registerPassword',
             'label' => __('text.password'),
@@ -60,7 +60,7 @@
             'type' => 'password'
         ])
         @include('global.partials.floating-label-input', [
-            'additional' => 'wire:model="registerPasswordConfirm"',
+            'additional' => 'wire:model="registerPasswordConfirm" autocomplete="new-password"',
             'id' => 'register-password-confirm',
             'name' => 'registerPasswordConfirm',
             'label' => __('text.confirm_password'),

--- a/resources/views/tester/auth.blade.php
+++ b/resources/views/tester/auth.blade.php
@@ -9,7 +9,7 @@
         @csrf
         <div class="mb-3">
             <label for="password" class="block mb-2">{{ __('text.password') }}</label>
-            <input type="password" name="password" id="password" autocomplete="off" class="shadow appearance-none border border-red rounded w-full py-2 px-3 text-gray-700 mb-2 leading-tight focus:outline-none focus:shadow-outline">
+            <input type="password" name="password" id="password" autocomplete="current-password" class="shadow appearance-none border border-red rounded w-full py-2 px-3 text-gray-700 mb-2 leading-tight focus:outline-none focus:shadow-outline">
         </div>
         <div class="flex items-center justify-between">
             <button class="btn" type="submit">


### PR DESCRIPTION
## Summary
- improve autocomplete for login fields
- enable autocomplete for tester password field

## Testing
- `php --version` *(fails: command not found)*
- `./vendor/bin/phpunit --stop-on-failure` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6851816f7ba4832092bc61e46fa2d8a5