### PR TITLE
Add keywords meta tags

### DIFF
--- a/resources/views/accounts/index-auth.blade.php
+++ b/resources/views/accounts/index-auth.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.account', ['title' => __('titles.account'), 'description' => __('descriptions.account'), 'active' => 'account', 'activeTool' => 'account', 'activeTool' => 'overview'])
+@extends('layouts.account', ['title' => __('titles.account'), 'description' => __('descriptions.account'), 'keywords' => __('keywords.account'), 'active' => 'account', 'activeTool' => 'account', 'activeTool' => 'overview'])
 
 @section('tool-content')
 <div class="mt-3">

--- a/resources/views/accounts/index.blade.php
+++ b/resources/views/accounts/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.account', ['title' => __('titles.account'), 'description' => __('descriptions.account'), 'active' => 'account', 'activeTool' => 'overview'])
+@extends('layouts.account', ['title' => __('titles.account'), 'description' => __('descriptions.account'), 'keywords' => __('keywords.account'), 'active' => 'account', 'activeTool' => 'overview'])
 
 @section('tool-content')
 <livewire:account />

--- a/resources/views/accounts/timetrack.blade.php
+++ b/resources/views/accounts/timetrack.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('text.timetracking'), 'description' => __('descriptions.home')])
+@extends('layouts.app', ['title' => __('text.timetracking'), 'description' => __('descriptions.home'), 'keywords' => __('keywords.home')])
 
 @section('content')
     <h1>{{ __('text.timetracking') }}</h1>

--- a/resources/views/contact/form.blade.php
+++ b/resources/views/contact/form.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('titles.contact'), 'description' => __('descriptions.contact'), 'active' => 'contact', 'activeTool' => $email])
+@extends('layouts.app', ['title' => __('titles.contact'), 'description' => __('descriptions.contact'), 'keywords' => __('keywords.contact'), 'active' => 'contact', 'activeTool' => $email])
 
 @section('content')
     <h1>{{ __('text.contact') }}</h1>

--- a/resources/views/cv/index.blade.php
+++ b/resources/views/cv/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('titles.cv'), 'description' => __('descriptions.cv'), 'active' => 'cv'])
+@extends('layouts.app', ['title' => __('titles.cv'), 'description' => __('descriptions.cv'), 'keywords' => __('keywords.cv'), 'active' => 'cv'])
 
 @section('content')
 <div class="overflow-x-hidden">

--- a/resources/views/cv/print.blade.php
+++ b/resources/views/cv/print.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.minimal', ['title' => $user->name . "'s " . __('text.cv'), 'description' => __('descriptions.cv'), 'active' => 'cv', 'print' => true, 'dark' => false])
+@extends('layouts.minimal', ['title' => $user->name . "'s " . __('text.cv'), 'description' => __('descriptions.cv'), 'keywords' => __('keywords.cv'), 'active' => 'cv', 'print' => true, 'dark' => false])
 
 @section('content')
 <style>

--- a/resources/views/cv/single.blade.php
+++ b/resources/views/cv/single.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => $user->name . "'s " . __('text.cv'), 'description' => __('descriptions.cv'), 'active' => 'cv', 'dark' => false])
+@extends('layouts.app', ['title' => $user->name . "'s " . __('text.cv'), 'description' => __('descriptions.cv'), 'keywords' => __('keywords.cv'), 'active' => 'cv', 'dark' => false])
 
 @section('content')
     @include('cv.content', ['cv' => $cv, 'user' => $user])

--- a/resources/views/datenschutz.blade.php
+++ b/resources/views/datenschutz.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('titles.data-protection')])
+@extends('layouts.app', ['title' => __('titles.data-protection'), 'description' => __('descriptions.data-protection'), 'keywords' => __('keywords.data-protection')])
 
 @section('content')
 <div class="break-words break-all whitespace-normal">

--- a/resources/views/global/head/og-tags.blade.php
+++ b/resources/views/global/head/og-tags.blade.php
@@ -5,12 +5,17 @@
     <meta property="og:description" content="{{ $description }}" />
     <meta name="description" content="{{ $description }}" />
 @endif
+@if (isset($keywords) && empty($from))
+    <meta name="keywords" content="{{ $keywords }}" />
+@endif
 @if (isset($from))
 @php
 $descKey = isset($from) ? 'descriptions.' . $from : 'descriptions.default';
+$keywordsKey = isset($from) ? 'keywords.' . $from : 'keywords.default';
 @endphp
     <meta property="og:description" content="{{ __($descKey) }}" />
     <meta name="description" content="{{ __($descKey) }}" />
+    <meta name="keywords" content="{{ __($keywordsKey) }}" />
 @endif
 <meta name="robots" content="index, follow"/>
 <link rel="canonical" href="{{ url()->current() }}" />

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('titles.home'), 'description' => __('descriptions.home'), 'dark' => false])
+@extends('layouts.app', ['title' => __('titles.home'), 'description' => __('descriptions.home'), 'keywords' => __('keywords.home'), 'dark' => false])
 
 @section('content')
 <h1>{{ __('text.welcome') }}</h1>

--- a/resources/views/impressum.blade.php
+++ b/resources/views/impressum.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('titles.imprint')])
+@extends('layouts.app', ['title' => __('titles.imprint'), 'description' => __('descriptions.imprint'), 'keywords' => __('keywords.imprint')])
 
 @section('content')
 {!! __('text.imprint-page') !!}

--- a/resources/views/layouts/account.blade.php
+++ b/resources/views/layouts/account.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => ($title ? $title : ''), 'active' => $active, 'activeTool' => $activeTool])
+@extends('layouts.app', ['title' => ($title ? $title : ''), 'description' => $description ?? null, 'keywords' => $keywords ?? null, 'active' => $active, 'activeTool' => $activeTool])
 
 @section('content')
 <h1>{{ $title }}</h1>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,7 +12,7 @@
         @include('global.head.font-preload')
         @include('global.head.app-css-preload')
         @include('global.head.title', ['title' => $title ?? null])
-        @include('global.head.og-tags', ['title' => $title ?? null, 'description' => $description ?? null])
+        @include('global.head.og-tags', ['title' => $title ?? null, 'description' => $description ?? null, 'keywords' => $keywords ?? null])
 
         @vite([
             'resources/css/app.css',

--- a/resources/views/layouts/minimal.blade.php
+++ b/resources/views/layouts/minimal.blade.php
@@ -10,7 +10,7 @@
 
         @include('global.head.font-preload')
         @include('global.head.title', ['title' => $title ?? null])
-        @include('global.head.og-tags', ['title' => $title ?? null])
+        @include('global.head.og-tags', ['title' => $title ?? null, 'description' => $description ?? null, 'keywords' => $keywords ?? null])
         <style>
         {!! Vite::content('resources/css/app.css') !!}
         </style>

--- a/resources/views/portfolio/list.blade.php
+++ b/resources/views/portfolio/list.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('titles.portfolio'), 'description' => __('descriptions.portfolio'), 'active' => 'portfolio'])
+@extends('layouts.app', ['title' => __('titles.portfolio'), 'description' => __('descriptions.portfolio'), 'keywords' => __('keywords.portfolio'), 'active' => 'portfolio'])
 
 @section('content')
     <h1>{{ __('text.portfolio') }}</h1>

--- a/resources/views/rt-share/index.blade.php
+++ b/resources/views/rt-share/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('titles.rt-share'), 'description' => __('descriptions.rt-share'), 'active' => 'rt-share'])
+@extends('layouts.app', ['title' => __('titles.rt-share'), 'description' => __('descriptions.rt-share'), 'keywords' => __('keywords.rt-share'), 'active' => 'rt-share'])
 
 @section('content')
 <h1>{{ __('text.rt-share') }}</h1>

--- a/resources/views/teams/index.blade.php
+++ b/resources/views/teams/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('titles.random-teams'), 'description' => __('descriptions.random-teams'), 'active' => 'teams'])
+@extends('layouts.app', ['title' => __('titles.random-teams'), 'description' => __('descriptions.random-teams'), 'keywords' => __('keywords.random-teams'), 'active' => 'teams'])
 
 @section('content')
 <h1>{{ __('text.random-teams') }}</h1>

--- a/resources/views/tester/auth.blade.php
+++ b/resources/views/tester/auth.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => 'Tester Auth', 'active' => 'tester', 'activeTool' => 'tester'])
+@extends('layouts.app', ['title' => 'Tester Auth', 'keywords' => __('keywords.tester'), 'active' => 'tester', 'activeTool' => 'tester'])
 
 @section('content')
     <h1>Tester</h1>

--- a/resources/views/tester/index.blade.php
+++ b/resources/views/tester/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('titles.tester'), 'description' => __('descriptions.tester'), 'active' => 'tester', 'activeTool' => 'tester'])
+@extends('layouts.app', ['title' => __('titles.tester'), 'description' => __('descriptions.tester'), 'keywords' => __('keywords.tester'), 'active' => 'tester', 'activeTool' => 'tester'])
 
 @section('content')
     <h1>Tester</h1>

--- a/resources/views/tester/instance.blade.php
+++ b/resources/views/tester/instance.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('text.testinstance') . ' ' . $instance->created_at_clean, 'active' => 'tester', 'activeTool' => 'tester'])
+@extends('layouts.app', ['title' => __('text.testinstance') . ' ' . $instance->created_at_clean, 'keywords' => __('keywords.tester'), 'active' => 'tester', 'activeTool' => 'tester'])
 
 @section('content')
     <h1>{{ __('text.testinstance') }} {{$instance->created_at_clean}}</h1>

--- a/resources/views/tester/objectdiff.blade.php
+++ b/resources/views/tester/objectdiff.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' =>  __('text.testobject') . ' ' . $testobject->name, 'active' => 'tester', 'activeTool' => 'tester'])
+@extends('layouts.app', ['title' =>  __('text.testobject') . ' ' . $testobject->name, 'keywords' => __('keywords.tester'), 'active' => 'tester', 'activeTool' => 'tester'])
 
 @section('content')
     @vite(['resources/css/diff-table.css'])

--- a/resources/views/tester/objectsearch.blade.php
+++ b/resources/views/tester/objectsearch.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' =>  __('text.testobject') . ' ' . $testobject->name, 'active' => 'tester', 'activeTool' => 'tester'])
+@extends('layouts.app', ['title' =>  __('text.testobject') . ' ' . $testobject->name, 'keywords' => __('keywords.tester'), 'active' => 'tester', 'activeTool' => 'tester'])
 
 @section('content')
     @livewire('testobject-search', ['testobject' => $testobject])

--- a/resources/views/tester/testobject.blade.php
+++ b/resources/views/tester/testobject.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' =>  __('text.testobject') . ' ' . $testobject->name, 'active' => 'tester', 'activeTool' => 'tester'])
+@extends('layouts.app', ['title' =>  __('text.testobject') . ' ' . $testobject->name, 'keywords' => __('keywords.tester'), 'active' => 'tester', 'activeTool' => 'tester'])
 
 @section('content')
     <h1>{{ __('text.testobject') }} {{$testobject->name}}</h1>

--- a/resources/views/tester/testrun.blade.php
+++ b/resources/views/tester/testrun.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.app', ['title' => __('text.testrun') . ' ' . $testrun->name . ' ' . $testrun->created_at_clean, 'active' => 'tester', 'activeTool' => 'tester'])
+@extends('layouts.app', ['title' => __('text.testrun') . ' ' . $testrun->name . ' ' . $testrun->created_at_clean, 'keywords' => __('keywords.tester'), 'active' => 'tester', 'activeTool' => 'tester'])
 
 @section('content')
     <h1>{{ __('text.testrun') }} {{$testrun->name}} {{$testrun->created_at_clean}}</h1>


### PR DESCRIPTION
## Summary
- add meta keywords to OG tags template and include translations
- pass keywords data through layout templates
- localize keywords across pages

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68518360f9dc832096cbc0422e9edb32