### PR TITLE
Add indexes to redirect_hit table

### DIFF
--- a/database/migrations/2025_06_08_100000_redirect_hit_add_indexes.php
+++ b/database/migrations/2025_06_08_100000_redirect_hit_add_indexes.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('redirect_hit', function (Blueprint $table) {
+            $table->index('redirect');
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('redirect_hit', function (Blueprint $table) {
+            $table->dropIndex(['redirect']);
+            $table->dropIndex(['created_at']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add index migration for redirect_hit table
- include down() logic for index removal

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_68518927b168832095a7ebd6bb78a656