### PR TITLE
Add db indexes for slug and user

### DIFF
--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -13,6 +13,13 @@ class Note extends Model
     protected $table = "note";
     protected $primaryKey = "id";
 
+    /**
+     * Database indexes for this model.
+     *
+     * @var array<int, string>
+     */
+    protected $indexes = ["slug", "user"];
+
     protected $attributes = [
         "name" => "Neue Notiz",
         "content" => "",

--- a/app/Models/Redirect.php
+++ b/app/Models/Redirect.php
@@ -12,6 +12,13 @@ class Redirect extends Model
     protected $table = "redirect";
     protected $primaryKey = "id";
 
+    /**
+     * Database indexes for this model.
+     *
+     * @var array<int, string>
+     */
+    protected $indexes = ["slug", "user"];
+
     protected $attributes = [
         "name" => "Neue Weiterleitung",
         "slug" => "neue-weiterleitung",

--- a/app/Models/RssFeed.php
+++ b/app/Models/RssFeed.php
@@ -13,6 +13,15 @@ class RssFeed extends Model
     protected $table = 'rss_feed';
     protected $primaryKey = 'id';
 
+    /**
+     * Database indexes for this model.
+     *
+     * @var array<int, string>
+     */
+    protected $indexes = [
+        'user',
+    ];
+
     protected $attributes = [
         'name' => 'New RSS Feed',
         'url' => 'https://example.com/feed.xml',

--- a/database/migrations/2025_06_17_153144_add_indexes_to_redirect_note_rss.php
+++ b/database/migrations/2025_06_17_153144_add_indexes_to_redirect_note_rss.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('redirect', function (Blueprint $table) {
+            $table->index('slug');
+            $table->index('user');
+        });
+
+        Schema::table('note', function (Blueprint $table) {
+            $table->index('slug');
+            $table->index('user');
+        });
+
+        Schema::table('rss_feed', function (Blueprint $table) {
+            $table->index('user');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('redirect', function (Blueprint $table) {
+            $table->dropIndex(['slug']);
+            $table->dropIndex(['user']);
+        });
+
+        Schema::table('note', function (Blueprint $table) {
+            $table->dropIndex(['slug']);
+            $table->dropIndex(['user']);
+        });
+
+        Schema::table('rss_feed', function (Blueprint $table) {
+            $table->dropIndex(['user']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add indexes on redirect.slug, redirect.user, note.slug, note.user, rss_feed.user
- document indexes in related Eloquent models

## Testing
- `php artisan migrate --force --no-interaction`
- `./vendor/bin/phpunit --exclude-group vendor --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_685189b67c288320b67f55dbb21c1f87