### PR TITLE
Add async jobs for delete & diff loops

### DIFF
--- a/app/Jobs/DeleteTestobjectDataJob.php
+++ b/app/Jobs/DeleteTestobjectDataJob.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Testobject;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+
+class DeleteTestobjectDataJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected int $testobjectId;
+
+    public function __construct(int $testobjectId)
+    {
+        $this->testobjectId = $testobjectId;
+    }
+
+    public function handle(): void
+    {
+        $testobject = Testobject::find($this->testobjectId);
+        if (! $testobject) {
+            return;
+        }
+
+        foreach ($testobject->testruns as $run) {
+            foreach ($run->testinstances as $instance) {
+                $instance->delete();
+            }
+            $run->delete();
+        }
+
+        Cache::put("delete-all-completed-{$this->testobjectId}", true, now()->addMinutes(5));
+    }
+}

--- a/app/Jobs/GenerateBulkDiffJob.php
+++ b/app/Jobs/GenerateBulkDiffJob.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Testobject;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+
+class GenerateBulkDiffJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected int $testobjectId;
+
+    public function __construct(int $testobjectId)
+    {
+        $this->testobjectId = $testobjectId;
+    }
+
+    public function handle(): void
+    {
+        $testobject = Testobject::find($this->testobjectId);
+        if (! $testobject) {
+            return;
+        }
+
+        $html = '';
+        foreach ($testobject->testruns as $run) {
+            if ($run->testinstances->count() >= 2) {
+                $a = $run->testinstances[0];
+                $b = $run->testinstances[1];
+                $html .= '<h3>' . $run->name . '</h3>';
+                $html .= $a->diff($b, 'Inline');
+            }
+        }
+
+        Cache::put("bulk-diff-content-{$this->testobjectId}", $html, now()->addMinutes(5));
+        Cache::put("bulk-diff-completed-{$this->testobjectId}", true, now()->addMinutes(5));
+    }
+}

--- a/resources/views/livewire/testobject.blade.php
+++ b/resources/views/livewire/testobject.blade.php
@@ -48,6 +48,11 @@
         <span wire:loading.remove wire:target="deleteAll">{{ __('text.delete_all') }}</span>
         <img wire:loading wire:target="deleteAll" class="w-4 h-4 m-auto animate-spin invert" src="{{ Vite::asset('resources/icons/sync.svg') }}"  alt="{{ __('alt.sync') }}" title="{{ __('alt.sync') }}"/>
     </button>
+    @if ($deleteStatus === 'running')
+        <div wire:poll.1000ms="updateDeleteStatus">Deleting...</div>
+    @elseif ($deleteStatus === 'completed')
+        <div>{{ __('text.all_deleted') }}</div>
+    @endif
 
     <p>{{ count($testobject->testruns) }} Testruns</p>
 


### PR DESCRIPTION
## Summary
- queue up deletion of all runs
- queue up testobject bulk diff generation
- show progress on delete action

## Testing
- `composer test` *(fails: composer not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685189d33c688320b3cef8d962c39a8a